### PR TITLE
Add `module`, which is the new `jsnext:main`

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ function sortPackageJson(packageJson) {
     'contributors',
     'files',
     'main',
+    'module',
     'jsnext:main',
     'types',
     'typings',


### PR DESCRIPTION
Both rollup.js and Webpack 2 now support `module` over `jsnext:main`,
so let's get that added.

See the [Rollup.js docs](https://github.com/rollup/rollup/wiki/pkg.module).