### PR TITLE
Add Jest as a sortable key

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function sortPackageJson(packageJson) {
   sortSubKey('browserify');
   sortSubKey('babel');
   sortSubKey('eslintConfig');
+  sortSubKey('jest');
   sortSubKey('dependencies');
   sortSubKey('devDependencies');
   sortSubKey('peerDependencies');
@@ -107,6 +108,7 @@ function sortPackageJson(packageJson) {
     'babel',
     'eslintConfig',
     'stylelint',
+    'jest',
     'dependencies',
     'devDependencies',
     'peerDependencies',


### PR DESCRIPTION
This commit adds `jest` as a sortable key, right after the linting keys.

[Jest offers tons of configuration](https://facebook.github.io/jest/docs/en/configuration.html) that you might want to stick in your `package.json`. I came across this project because I needed it, and this key was missing based on our own needs. Figuring since Jest is at least one of the most popular testing frameworks out there, this should make the cut.