### PR TITLE
feat: Add support for specifying location

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ cat package.json
 }
 $ npm i -g sort-package-json
 $ sort-package-json
-Ok, your package.json is sorted
+/my-project/package.json is sorted!
 $ cat package.json
 {
   "name": "foo",
@@ -52,6 +52,12 @@ $ cat package.json
   ],
   "dependencies": {}
 }
+```
+
+`sort-package-json` also supports a single argument, telling it where it can find package.json file(s).
+
+```bash
+$ sort-package-json packages/*/package.json
 ```
 
 ### Install

--- a/index.js
+++ b/index.js
@@ -124,13 +124,18 @@ function sortPackageJson(packageJson) {
 }
 module.exports = sortPackageJson;
 module.exports.sortPackageJson = sortPackageJson;
+
 if (require.main === module) {
   var fs = require('fs');
-  var packageJsonPath = process.cwd() + '/package.json';
-  var packageJson = fs.readFileSync(packageJsonPath, 'utf8');
-  var sorted = sortPackageJson(packageJson);
-  if (sorted !== packageJson) {
-    fs.writeFileSync(packageJsonPath, sorted, 'utf8');
-    console.log('Ok, your package.json is sorted');
-  }
+
+  var filesToProcess = process.argv[2] ? process.argv.slice(2) : [process.cwd() + '/package.json'];
+  
+  filesToProcess.forEach(function (filePath) {
+    var packageJson = fs.readFileSync(filePath, 'utf8');
+    var sorted = sortPackageJson(packageJson);
+    if (sorted !== packageJson) {
+        fs.writeFileSync(filePath, sorted, 'utf8');
+        console.log(filePath + ' is sorted!');
+    }
+  });
 }


### PR DESCRIPTION
This commit adds support for specifying location(s) for the `package.json` file(s) to sort. 

This is particularly useful when you have a monorepo with tons of `package.json` files that need this command.