### PR TITLE
Add support for `eslintIgnore` key

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ function sortPackageJson(packageJson) {
     'browserify',
     'babel',
     'eslintConfig',
+    'eslintIgnore',
     'stylelint',
     'jest',
     'dependencies',


### PR DESCRIPTION
Since support for `eslintConfig` already exist, I think it would make sense to support the `eslintIgnore` key as well. This key is an alternative to defining ignored paths for eslint in a separate `.eslintignore` file, and consists of an array containing file blobs (should not be sorted).

https://eslint.org/docs/user-guide/configuring#using-eslintignore-in-packagejson