### PR TITLE
feat: sort betterScripts below scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ function sortPackageJson(packageJson) {
     'directories',
     'workspaces',
     'scripts',
+    'betterScripts',
     'config',
     'pre-commit',
     'browser',


### PR DESCRIPTION
This adds support for https://github.com/benoror/better-npm-run

I think it makes sense to have it directly below scripts, but I let you be the judge on that.