### PR TITLE
feat: add support for `betterScripts` key, below `scripts`

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ function sortPackageJson(packageJson) {
     'directories',
     'workspaces',
     'scripts',
+    'betterScripts',
     'config',
     'pre-commit',
     'browser',


### PR DESCRIPTION
This adds support for https://github.com/benoror/better-npm-run

I think it makes sense to have it directly below scripts, but I let you be the judge on that.

Note: the build is failing, but I really cannot understand, within the test, why it would. There doesn't seem to be any of your tests that would break from what I added.
Re: oops, wrong branch.