### PR TITLE
Ignore `pre` and `post` sort logic if script starts with "-"

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ function sortPackageJson(packageJson) {
    */
   function compareScriptKeys(a, b) {
     if (a === b) return 0;
-    var aScript = a.replace(/^(pre|post)(.)/, '$2');
-    var bScript = b.replace(/^(pre|post)(.)/, '$2');
+    var aScript = a.replace(/^(pre|post)([^-])/, '$2');
+    var bScript = b.replace(/^(pre|post)([^-])/, '$2');
     if (aScript === bScript) {
       // pre* is always smaller; post* is always bigger
       // Covers: pre* vs. *; pre* vs. post*; * vs. post*

--- a/test.js
+++ b/test.js
@@ -27,10 +27,12 @@ require('fs').readFile('./package.json', 'utf8', function (error, contents) {
       start: 'node server.js',
       posttest: 'abc',
       pretest: 'xyz',
+      'pre-fetch-info': 'foo'
     }
   }).scripts), [
     'postinstall',
     'multiply',
+    'pre-fetch-info',
     'start',
     'pretest',
     'test',


### PR DESCRIPTION
Use case:

Having "prescript", "postscript" and "script" should sort based on "script", just as it is now. This follows the logic that calling "script" will behind the scenes call "prescript" and "postscript".

Having "pre-script" or "post-script" won't be called when calling "script", it will if you call "-script", but that makes little sense, I don't think anyone would do that.

With that in mind, I suggest tweaking the sort algorithm to ignore these cases so they can be sorted into their natural places.