### PR TITLE
feat: Keep the "pre" when sorting certain scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ var sortOrder = [
   'preferGlobal',
   'publishConfig',
 ];
+var prefixedScriptBlacklist = [
+  'prepare',
+  'prettier',
+];
 
 function sortPackageJson(packageJson) {
   var wasString = false;
@@ -81,6 +85,12 @@ function sortPackageJson(packageJson) {
       packageJson[key] = sortObjectKeys(packageJson[key], sortList);
     }
   }
+  function toSortKey(script) {
+    if (prefixedScriptBlacklist.indexOf(script) >= 0) {
+      return script;
+    }
+    return script.replace(/^(pre|post)([^-])/, '$2');
+  }
   /*             b
    *       pre | * | post
    *   pre  0  | - |  -
@@ -89,8 +99,8 @@ function sortPackageJson(packageJson) {
    */
   function compareScriptKeys(a, b) {
     if (a === b) return 0;
-    var aScript = a.replace(/^(pre|post)([^-])/, '$2');
-    var bScript = b.replace(/^(pre|post)([^-])/, '$2');
+    var aScript = toSortKey(a);
+    var bScript = toSortKey(b);
     if (aScript === bScript) {
       // pre* is always smaller; post* is always bigger
       // Covers: pre* vs. *; pre* vs. post*; * vs. post*

--- a/test.js
+++ b/test.js
@@ -27,12 +27,16 @@ require('fs').readFile('./package.json', 'utf8', function (error, contents) {
       start: 'node server.js',
       posttest: 'abc',
       pretest: 'xyz',
+      prettier: 'prettier -l "**/*.js"',
+      prepare: 'npm run build',
       'pre-fetch-info': 'foo'
     }
   }).scripts), [
     'postinstall',
     'multiply',
     'pre-fetch-info',
+    'prepare',
+    'prettier',
     'start',
     'pretest',
     'test',


### PR DESCRIPTION
Before, "prepare" was being sorted as if it was named "pare" and "prettier" was being sorted as if it was named "ttier". These scripts are now sorted as is. This is done via a blacklist, so other similar scripts could be added later.