### PR TITLE
feat: sort few more keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var sortOrder = [
   'author',
   'contributors',
   'files',
+  'sideEffects',
   'main',
   'module',
   'jsnext:main',
@@ -32,10 +33,14 @@ var sortOrder = [
   'scripts',
   'betterScripts',
   'husky',
-  'config',
   'pre-commit',
+  'commitlint',
+  'lint-staged',
+  'config',
+  'nodemonConfig',
   'browserify',
   'babel',
+  'browserslist',
   'xo',
   'prettier',
   'eslintConfig',
@@ -148,8 +153,11 @@ function sortPackageJson(packageJson) {
   sortSubKey('directories', [ 'lib', 'bin', 'man', 'doc', 'example' ]);
   sortSubKey('repository', [ 'type', 'url' ]);
   sortSubKey('scripts', compareScriptKeys);
+  sortSubKey('betterScripts', compareScriptKeys);
+  sortSubKey('commitlint');
+  sortSubKey('lint-staged');
   sortSubKey('config');
-  sortSubKey('browser');
+  sortSubKey('nodemonConfig');
   sortSubKey('browserify');
   sortSubKey('babel');
   sortSubKey('eslintConfig');


### PR DESCRIPTION
- Added support for: `sideEffects`, `commitlint`, `lint-staged`, `nodemonConfig`, `browserslist` (2 out of 3 from #30)
- `betterScripts` now is also sorted with the same logic as for `scripts`
- Removed `sortSubKey('browser')` because it's a string usually (#51)
