### PR TITLE
feat: new eol detection logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const _sortObjectKeys = require('sort-object-keys')
 const detectIndent = require('detect-indent')
+const detectNewline = require('detect-newline').graceful
 const glob = require('glob')
 const sortObjectKeys = comp => x => _sortObjectKeys(x, comp)
 
@@ -119,15 +120,14 @@ const sortOrder = fields.map(({ key }) => key)
 
 function editStringJSON(json, over) {
   if (typeof json === 'string') {
-    const indentLevel = detectIndent(json).indent
+    const { indent } = detectIndent(json)
     const endCharacters = json.slice(-1) === '\n' ? '\n' : ''
-    const newlineMatch = json.match(/(\r?\n)/)
-    const hasWindowsNewlines = (newlineMatch && newlineMatch[0]) === '\r\n'
+    const newline = detectNewline(json)
     json = JSON.parse(json)
 
-    let result = JSON.stringify(over(json), null, indentLevel) + endCharacters
-    if (hasWindowsNewlines) {
-      result = result.replace(/\n/g, '\r\n')
+    let result = JSON.stringify(over(json), null, indent) + endCharacters
+    if (newline === '\r\n') {
+      result = result.replace(/\n/g, newline)
     }
     return result
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,12 @@
           "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
+        "detect-newline": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+          "dev": true
+        },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -962,10 +968,9 @@
       "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
     },
     "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
     },
     "dir-glob": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "detect-indent": "^6.0.0",
+    "detect-newline": "3.1.0",
     "glob": "^7.1.6",
     "sort-object-keys": "^1.1.2"
   },

--- a/test.js
+++ b/test.js
@@ -130,6 +130,10 @@ fs.readFile('./package.json', 'utf8', (error, contents) => {
     sortPackageJson('{\r\n  "foo": "bar"\r\n}\r\n'),
     '{\r\n  "foo": "bar"\r\n}\r\n',
   )
+  assert.strictEqual(
+    sortPackageJson('{\r\n  "foo": "bar"\n}\n'),
+    '{\n  "foo": "bar"\n}\n',
+  )
 })
 
 // fields tests


### PR DESCRIPTION
Use [`detect-newline`](https://github.com/sindresorhus/detect-newline) to detect `EOL`

Before, `EOL` is decided by first linebreak, 

After, 
> Detect the dominant newline character of a string

I think it's more reasonable