### PR TITLE
feat: support private keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,15 @@ function editStringJSON(json, over) {
 
 function sortPackageJson(jsonIsh, options = {}) {
   return editStringJSON(jsonIsh, json => {
-    const newJson = sortObjectKeys(options.sortOrder || sortOrder)(json)
+    const keys = Object.keys(json)
+    const privateKeys = keys.filter(key => key[0] === '_')
+    const publicKeys = keys.filter(key => key[0] !== '_')
+
+    const newJson = sortObjectKeys([
+      ...(options.sortOrder || sortOrder),
+      ...publicKeys.sort(),
+      ...privateKeys.sort(),
+    ])(json)
 
     for (const { key, over } of fields) {
       if (over && newJson[key]) newJson[key] = over(newJson[key])

--- a/index.js
+++ b/index.js
@@ -148,11 +148,19 @@ function editStringJSON(json, over) {
   return over(json)
 }
 
+const isPrivateKey = key => key[0] === '_'
+const partition = (array, predicate) =>
+  array.reduce(
+    (result, value) => {
+      result[predicate(value) ? 0 : 1].push(value)
+      return result
+    },
+    [[], []],
+  )
 function sortPackageJson(jsonIsh, options = {}) {
   return editStringJSON(jsonIsh, json => {
     const keys = Object.keys(json)
-    const privateKeys = keys.filter(key => key[0] === '_')
-    const publicKeys = keys.filter(key => key[0] !== '_')
+    const [privateKeys, publicKeys] = partition(keys, isPrivateKey)
 
     const newJson = sortObjectKeys([
       ...(options.sortOrder || sortOrder),

--- a/test.js
+++ b/test.js
@@ -136,6 +136,22 @@ fs.readFile('./package.json', 'utf8', (error, contents) => {
   )
 })
 
+// fields with '_' prefix should alway at bottom
+assert.deepStrictEqual(
+  Object.keys(
+    sortPackageJson({
+      _foo: '_foo',
+      foo: 'foo',
+      version: '1.0.0',
+      name: 'sort-package-json',
+      bar: 'bar',
+      _id: 'sort-package-json@1.0.0',
+      _bar: '_bar',
+    }),
+  ),
+  ['name', 'version', 'bar', 'foo', '_bar', '_foo', '_id'],
+)
+
 // fields tests
 
 // fields sort as object


### PR DESCRIPTION
npm offical package [`read-package-json`](https://www.npmjs.com/package/read-package-json) and popular package [`read-pkg`](https://www.npmjs.com/package/read-pkg) and [`read-pkg-up`](https://www.npmjs.com/package/read-pkg-up), add some private keys to json, like `_id`.

This PR make those private keys always at bottom. so we can easy read -> sort -> write, like this

```js
const {path, packageJson} = await readPkg()
const sorted = sortPackageJson(packageJson)
await writePkg(path, sorted)
```