### PR TITLE
feat: prepend custom order to default sort order

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ function sortPackageJson(jsonIsh, options = {}) {
       if (Array.isArray(sortOrder)) {
         const keys = Object.keys(json)
         const [privateKeys, publicKeys] = partition(keys, isPrivateKey)
-        sortOrder = [...sortOrder, ...publicKeys.sort(), ...privateKeys.sort()]
+        sortOrder = [...sortOrder, ...defaultSortOrder, ...publicKeys.sort(), ...privateKeys.sort()]
       }
 
       const newJson = sortObjectKeys(json, sortOrder)

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function sortPackageJson(jsonIsh, options = {}) {
           ...sortOrder,
           ...defaultSortOrder,
           ...publicKeys.sort(),
-          ...privateKeys.sort()
+          ...privateKeys.sort(),
         ]
       }
 

--- a/index.js
+++ b/index.js
@@ -180,16 +180,6 @@ const partition = (array, predicate) =>
     [[], []],
   )
 function sortPackageJson(jsonIsh, options = {}) {
-  let sortOrder = defaultSortOrder
-
-  if (options.sortOrder) {
-    if (Array.isArray(options.sortOrder)) {
-      sortOrder = [...options.sortOrder, ...defaultSortOrder]
-    } else {
-      sortOrder = options.sortOrder
-    }
-  }
-
   return editStringJSON(
     jsonIsh,
     onObject(json => {

--- a/index.js
+++ b/index.js
@@ -163,9 +163,15 @@ function editStringJSON(json, over) {
 }
 
 function sortPackageJson(jsonIsh, options = {}) {
-  const sortOrder = options.sortOrder
-    ? [...options.sortOrder, ...defaultSortOrder]
-    : defaultSortOrder
+  let sortOrder = defaultSortOrder
+
+  if (options.sortOrder) {
+    if (Array.isArray(options.sortOrder)) {
+      sortOrder = [...options.sortOrder, ...defaultSortOrder]
+    } else {
+      sortOrder = options.sortOrder
+    }
+  }
 
   return editStringJSON(
     jsonIsh,

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ const fields = [
   { key: 'publishConfig', over: sortObject },
 ]
 
-const sortOrder = fields.map(({ key }) => key)
+const defaultSortOrder = fields.map(({ key }) => key)
 
 function editStringJSON(json, over) {
   if (typeof json === 'string') {
@@ -149,8 +149,12 @@ function editStringJSON(json, over) {
 }
 
 function sortPackageJson(jsonIsh, options = {}) {
+  const sortOrder = options.sortOrder
+    ? [...options.sortOrder, ...defaultSortOrder]
+    : defaultSortOrder
+
   return editStringJSON(jsonIsh, json => {
-    const newJson = sortObjectKeys(options.sortOrder || sortOrder)(json)
+    const newJson = sortObjectKeys(sortOrder)(json)
 
     for (const { key, over } of fields) {
       if (over && newJson[key]) newJson[key] = over(newJson[key])
@@ -162,7 +166,7 @@ function sortPackageJson(jsonIsh, options = {}) {
 
 module.exports = sortPackageJson
 module.exports.sortPackageJson = sortPackageJson
-module.exports.sortOrder = sortOrder
+module.exports.sortOrder = defaultSortOrder
 
 if (require.main === module) {
   const fs = require('fs')

--- a/index.js
+++ b/index.js
@@ -188,7 +188,12 @@ function sortPackageJson(jsonIsh, options = {}) {
       if (Array.isArray(sortOrder)) {
         const keys = Object.keys(json)
         const [privateKeys, publicKeys] = partition(keys, isPrivateKey)
-        sortOrder = [...sortOrder, ...defaultSortOrder, ...publicKeys.sort(), ...privateKeys.sort()]
+        sortOrder = [
+          ...sortOrder,
+          ...defaultSortOrder,
+          ...publicKeys.sort(),
+          ...privateKeys.sort()
+        ]
       }
 
       const newJson = sortObjectKeys(json, sortOrder)

--- a/test.js
+++ b/test.js
@@ -94,6 +94,26 @@ fs.readFile('./package.json', 'utf8', (error, contents) => {
     ['z', 'a', 'name'],
   )
 
+  // defaultSortOrder still applied, when using custom sortOrder
+  assert.deepStrictEqual(
+    Object.keys(
+      sortPackageJson(
+        {
+          b: 'b',
+          a: 'a',
+          z: 'z',
+          version: '1.0.0',
+          name: 'foo',
+          private: true,
+        },
+        {
+          sortOrder: ['z', 'private'],
+        },
+      ),
+    ),
+    ['z', 'private', 'name', 'version', 'a', 'b'],
+  )
+
   // Custom sort order should not effect field sorting
   assert.deepStrictEqual(
     Object.keys(


### PR DESCRIPTION
Make custom sortOrder prepend to defaultSortOrder, instead of override it, so user only need send keys that must on top, the rest known fields still sort by defaultOrder.
Should be much easier to use.