### PR TITLE
fix: correct type of `man` `os` `cpu` field

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ const fields = [
   { key: 'examplestyle' },
   { key: 'assets' },
   { key: 'bin', over: sortObject },
-  { key: 'man', over: sortObject },
+  { key: 'man' },
   { key: 'directories', over: sortDirectories },
   { key: 'workspaces' },
   // node-pre-gyp https://www.npmjs.com/package/node-pre-gyp#1-add-new-entries-to-your-packagejson
@@ -137,8 +137,8 @@ const fields = [
   { key: 'resolutions', over: sortObject },
   { key: 'engines', over: sortObject },
   { key: 'engineStrict', over: sortObject },
-  { key: 'os', over: sortObject },
-  { key: 'cpu', over: sortObject },
+  { key: 'os' },
+  { key: 'cpu' },
   { key: 'preferGlobal', over: sortObject },
   { key: 'publishConfig', over: sortObject },
 ]

--- a/test.js
+++ b/test.js
@@ -155,7 +155,6 @@ fs.readFile('./package.json', 'utf8', (error, contents) => {
 for (const field of [
   'exports',
   'bin',
-  'man',
   'commitlint',
   'lint-staged',
   'config',
@@ -172,8 +171,6 @@ for (const field of [
   'resolutions',
   'engines',
   'engineStrict',
-  'os',
-  'cpu',
   'preferGlobal',
   'publishConfig',
 ]) {
@@ -217,6 +214,7 @@ for (const field of [
   'example',
   'examplestyle',
   'assets',
+  'man',
   'workspaces',
   'husky',
   'pre-commit',
@@ -224,6 +222,8 @@ for (const field of [
   'eslintIgnore',
   'stylelint',
   'flat',
+  'os',
+  'cpu',
 ]) {
   testField(field, [
     {


### PR DESCRIPTION
 `man` `os` `cpu` are all `array`. 

for `os` and `cpu`, they support negative values.
So, in theory it could be `['darwin', '!darwin']`, order should matters, we don't want break it. 
It could also be `['darwin', '!darwin', 'darwin']`, so `uniq` may also break it.

for `man` field, I'm not familiar with `man` command, not sure we should do anything.

@keithamus thoughts?
