### PR TITLE
feat: sort `eslintConfig`

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,20 @@ const sortDirectories = sortObjectBy([
 const sortProperty = (property, over) => object =>
   Object.assign(object, { [property]: over(object[property]) })
 const sortGitHooks = sortObjectBy(gitHooks)
+const sortESLintConfig = sortObjectBy([
+  'env',
+  'parser',
+  'parserOptions',
+  'settings',
+  'plugins',
+  'extends',
+  'rules',
+  'overrides',
+  'globals',
+  'processor',
+  'noInlineConfig',
+  'reportUnusedDisableDirectives',
+])
 
 // See https://docs.npmjs.com/misc/scripts
 const defaultNpmScripts = new Set([
@@ -132,7 +146,7 @@ const fields = [
   { key: 'browserslist' },
   { key: 'xo', over: sortObject },
   { key: 'prettier', over: sortObject },
-  { key: 'eslintConfig', over: sortObject },
+  { key: 'eslintConfig', over: sortESLintConfig },
   { key: 'eslintIgnore' },
   { key: 'stylelint' },
   { key: 'ava', over: sortObject },

--- a/test.js
+++ b/test.js
@@ -198,7 +198,6 @@ for (const field of [
   'babel',
   'xo',
   'prettier',
-  'eslintConfig',
   'ava',
   'jest',
   'mocha',
@@ -286,6 +285,19 @@ testField('husky', [
       },
     },
     expect: ['pre-commit', 'commit-msg', UNKNOWN],
+  },
+])
+
+testField('eslintConfig', [
+  {
+    value: {
+      overrides: [],
+      extends: ['standard', 'plugin:prettier/recommended', 'prettier/standard'],
+      [UNKNOWN]: UNKNOWN,
+      rules: {},
+      plugins: ['prettier'],
+    },
+    expect: ['plugins', 'extends', 'rules', 'overrides', UNKNOWN],
   },
 ])
 


### PR DESCRIPTION
Sort `eslintConfig` object, the ordering of key in my personal opinion, all keys can found [here](https://github.com/eslint/eslint/blob/acc0e47572a9390292b4e313b4a4bf360d236358/conf/config-schema.js).

But question is this too much for us?

If we start doing this kind of sorting, we may need sort other libs.
If not, we might want disable sorting for `eslintConfig`.