### PR TITLE
fix: missing type check on `sortScripts`

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const defaultNpmScripts = new Set([
   'version',
 ])
 
-const sortScripts = scripts => {
+const sortScripts = onObject(scripts => {
   const names = Object.keys(scripts)
   const prefixable = new Set()
 
@@ -137,7 +137,7 @@ const sortScripts = scripts => {
   )
 
   return sortObjectBy(order)(scripts)
-}
+})
 
 // fields marked `vscode` are for `Visual Studio Code extension manifest` only
 // https://code.visualstudio.com/api/references/extension-manifest

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const sortScripts = onObject(scripts => {
     [],
   )
 
-  return sortObjectBy(order)(scripts)
+  return sortObjectKeys(scripts, order)
 })
 
 // fields marked `vscode` are for `Visual Studio Code extension manifest` only

--- a/tests/_helpers.js
+++ b/tests/_helpers.js
@@ -84,8 +84,8 @@ function asItIs(t, { path, options }, excludeTypes = []) {
     )
   }
 
-  for (const value of ['string', false, 2020]) {
-    const type = typeof value
+  for (const value of ['string', false, 2020, undefined, null]) {
+    const type = value === null ? 'null' : typeof value
     if (!excludeTypes.includes(type)) {
       t.is(
         sortPackageJsonAsObject({ path, value, options }),


### PR DESCRIPTION
```text
require('sort-package-json')({scripts: undefined})
Thrown:
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at sortScripts (<cwd>\node_modules\sort-package-json\index.js:117:24)
```