### PR TITLE
Update prettier to 2.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         run: npm ci
 
       - name: Run ESLint
+        if: matrix.node_version == '12'
         run: npm run lint
 
       - name: Check package.json
@@ -40,7 +41,7 @@ jobs:
 
       - name: Run Tests
         run: npm run test-coverage
-        
+
       - name: Release
         if: github.ref == 'master'
         run: npm run semantic-release

--- a/cli.js
+++ b/cli.js
@@ -3,12 +3,12 @@ const fs = require('fs')
 const globby = require('globby')
 const sortPackageJson = require('.')
 
-const isCheckFlag = argument => argument === '--check' || argument === '-c'
+const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
 
 const cliArguments = process.argv.slice(2)
 const isCheck = cliArguments.some(isCheckFlag)
 
-const patterns = cliArguments.filter(argument => !isCheckFlag(argument))
+const patterns = cliArguments.filter((argument) => !isCheckFlag(argument))
 
 if (!patterns.length) {
   patterns[0] = 'package.json'
@@ -23,7 +23,7 @@ if (files.length === 0) {
 
 let notSortedFiles = 0
 
-files.forEach(file => {
+files.forEach((file) => {
   const packageJson = fs.readFileSync(file, 'utf8')
   const sorted = sortPackageJson(packageJson)
 

--- a/index.js
+++ b/index.js
@@ -6,16 +6,16 @@ const isPlainObject = require('is-plain-obj')
 
 const hasOwnProperty = (object, property) =>
   Object.prototype.hasOwnProperty.call(object, property)
-const pipe = fns => x => fns.reduce((result, fn) => fn(result), x)
-const onArray = fn => x => (Array.isArray(x) ? fn(x) : x)
-const onStringArray = fn => x =>
-  Array.isArray(x) && x.every(item => typeof item === 'string') ? fn(x) : x
-const uniq = onStringArray(xs => xs.filter((x, i) => i === xs.indexOf(x)))
-const sortArray = onStringArray(array => [...array].sort())
+const pipe = (fns) => (x) => fns.reduce((result, fn) => fn(result), x)
+const onArray = (fn) => (x) => (Array.isArray(x) ? fn(x) : x)
+const onStringArray = (fn) => (x) =>
+  Array.isArray(x) && x.every((item) => typeof item === 'string') ? fn(x) : x
+const uniq = onStringArray((xs) => xs.filter((x, i) => i === xs.indexOf(x)))
+const sortArray = onStringArray((array) => [...array].sort())
 const uniqAndSortArray = pipe([uniq, sortArray])
-const onObject = fn => x => (isPlainObject(x) ? fn(x) : x)
+const onObject = (fn) => (x) => (isPlainObject(x) ? fn(x) : x)
 const sortObjectBy = (comparator, deep) => {
-  const over = onObject(object => {
+  const over = onObject((object) => {
     object = sortObjectKeys(object, comparator)
     if (deep) {
       for (const [key, value] of Object.entries(object)) {
@@ -38,7 +38,7 @@ const sortDirectories = sortObjectBy([
   'example',
   'test',
 ])
-const overProperty = (property, over) => object =>
+const overProperty = (property, over) => (object) =>
   hasOwnProperty(object, property)
     ? Object.assign(object, { [property]: over(object[property]) })
     : object
@@ -72,7 +72,7 @@ const sortEslintConfig = onObject(
     overProperty('globals', sortObject),
     overProperty(
       'overrides',
-      onArray(overrides => overrides.map(sortEslintConfig)),
+      onArray((overrides) => overrides.map(sortEslintConfig)),
     ),
     overProperty('parserOptions', sortObject),
     overProperty(
@@ -91,10 +91,10 @@ const sortVSCodeBadgeObject = sortObjectBy(['description', 'url', 'href'])
 const sortPrettierConfig = onObject(
   pipe([
     // sort keys alphabetically, but put `overrides` at bottom
-    config =>
+    (config) =>
       sortObjectKeys(config, [
         ...Object.keys(config)
-          .filter(key => key !== 'overrides')
+          .filter((key) => key !== 'overrides')
           .sort(),
         'overrides',
       ]),
@@ -102,7 +102,7 @@ const sortPrettierConfig = onObject(
     overProperty(
       'overrides',
       // and `config.overrides` is an array
-      onArray(overrides =>
+      onArray((overrides) =>
         overrides.map(
           pipe([
             // sort `config.overrides[]` alphabetically
@@ -131,12 +131,12 @@ const defaultNpmScripts = new Set([
   'version',
 ])
 
-const sortScripts = onObject(scripts => {
+const sortScripts = onObject((scripts) => {
   const names = Object.keys(scripts)
   const prefixable = new Set()
 
   const keys = names
-    .map(name => {
+    .map((name) => {
       const omitted = name.replace(/^(?:pre|post)/, '')
       if (defaultNpmScripts.has(omitted) || names.includes(omitted)) {
         prefixable.add(omitted)
@@ -183,7 +183,7 @@ const fields = [
   { key: 'author', over: sortPeopleObject },
   {
     key: 'contributors',
-    over: onArray(contributors => contributors.map(sortPeopleObject)),
+    over: onArray((contributors) => contributors.map(sortPeopleObject)),
   },
   /* vscode */ { key: 'publisher' },
   { key: 'sideEffects' },
@@ -263,7 +263,7 @@ const fields = [
   /* vscode */ { key: 'icon' },
   /* vscode */ {
     key: 'badges',
-    over: onArray(badge => badge.map(sortVSCodeBadgeObject)),
+    over: onArray((badge) => badge.map(sortVSCodeBadgeObject)),
   },
   /* vscode */ { key: 'galleryBanner', over: sortObject },
   /* vscode */ { key: 'preview' },
@@ -297,7 +297,7 @@ function editStringJSON(json, over) {
   return over(json)
 }
 
-const isPrivateKey = key => key[0] === '_'
+const isPrivateKey = (key) => key[0] === '_'
 const partition = (array, predicate) =>
   array.reduce(
     (result, value) => {
@@ -309,7 +309,7 @@ const partition = (array, predicate) =>
 function sortPackageJson(jsonIsh, options = {}) {
   return editStringJSON(
     jsonIsh,
-    onObject(json => {
+    onObject((json) => {
       let sortOrder = options.sortOrder ? options.sortOrder : defaultSortOrder
 
       if (Array.isArray(sortOrder)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9576,9 +9576,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "lint-staged": "^10.0.8",
     "make-dir": "3.0.2",
     "nyc": "^15.0.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "semantic-release": "17.0.4",
     "tempy": "0.4.0"
   }

--- a/tests/_helpers.js
+++ b/tests/_helpers.js
@@ -171,7 +171,7 @@ async function testCLI(t, { fixtures = [], args, message }) {
 }
 
 function runCLI({ args = [], cwd = process.cwd() }) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     execFile('node', [cliScript, ...args], { cwd }, (error, stdout, stderr) => {
       resolve({ errorCode: error && error.code, stdout, stderr })
     })

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -11,7 +11,7 @@ const goodJson = {
   version: '1.0.0',
 }
 
-test('cli', t => {
+test('cli', (t) => {
   t.notThrows(
     () => fs.accessSync(cliScript, fs.constants.X_OK),
     'CLI should be executable.',

--- a/tests/eslint.js
+++ b/tests/eslint.js
@@ -60,7 +60,7 @@ for (const key of [
   test(path, macro.asItIs, { path })
 }
 
-test('eslintConfig.override[]', t => {
+test('eslintConfig.override[]', (t) => {
   const eslintConfigWithOverrides = {
     eslintConfig: {
       overrides: [

--- a/tests/fields.js
+++ b/tests/fields.js
@@ -179,7 +179,7 @@ test('directories', macro.sortObject, {
   },
 })
 
-test('contributors', t => {
+test('contributors', (t) => {
   const contributors = {
     contributors: [
       {
@@ -208,7 +208,7 @@ test('contributors', t => {
   )
 })
 
-test('badges', t => {
+test('badges', (t) => {
   const badges = {
     badges: [
       {

--- a/tests/main.js
+++ b/tests/main.js
@@ -4,7 +4,7 @@ const { macro, keysToObject } = require('./_helpers')
 
 const fields = [...sortPackageJson.sortOrder].sort()
 
-test('main', t => {
+test('main', (t) => {
   const packageJson = { version: '1.0.0', name: 'sort-package-json' }
 
   t.is(

--- a/tests/prettier.js
+++ b/tests/prettier.js
@@ -17,7 +17,7 @@ test('prettier', macro.sortObject, {
   },
 })
 
-test('prettier.overrides[]', t => {
+test('prettier.overrides[]', (t) => {
   const prettierConfig = {
     prettier: {
       overrides: [
@@ -43,7 +43,7 @@ test('prettier.overrides[]', t => {
   )
 })
 
-test('prettier.overrides[].options', t => {
+test('prettier.overrides[].options', (t) => {
   const config = {
     prettier: {
       overrides: [

--- a/tests/white-space.js
+++ b/tests/white-space.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const sortPackageJson = require('..')
 
-test('white space', t => {
+test('white space', (t) => {
   t.is(sortPackageJson('{}'), '{}')
   t.is(sortPackageJson('{}\n'), '{}\n')
   t.is(sortPackageJson('{}\r\n'), '{}\r\n')


### PR DESCRIPTION
This updates `prettier` to `2.0.4`. Note that the new version comes with several minor style updates as well, which requires code changes in the same commit (which is why #164 failed).

This also removes Node.js 8 from the GitHub Actions test matrix. @keithamus - If you require Node.js 8 compatibility, please close this PR (as well as #164). Node.js 8 is [no longer supported](https://nodejs.org/en/about/releases/), and Prettier 2 seems to be incompatible with it

Supersedes and closes #164