### PR TITLE
feat: update lifecycle logic to handle - after prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ const sortScripts = onObject((scripts) => {
 
   const keys = names
     .map((name) => {
-      const omitted = name.replace(/^(?:pre|post)/, '')
+      const omitted = name.replace(/^(?:pre-|post-|pre|post)/, '')
       if (defaultNpmScripts.has(omitted) || names.includes(omitted)) {
         prefixable.add(omitted)
         return omitted
@@ -149,7 +149,7 @@ const sortScripts = onObject((scripts) => {
   const order = keys.reduce(
     (order, key) =>
       order.concat(
-        prefixable.has(key) ? [`pre${key}`, key, `post${key}`] : [key],
+        prefixable.has(key) ? [`pre${key}`, `pre-${key}`, key, `post${key}`, `post-${key}`] : [key],
       ),
     [],
   )


### PR DESCRIPTION
I don't think that this should affect any. I am working on a plugin for yarn 2 to add lifecycle handing.
As they say in their docs using just `pre` and `post` can have odd side effects. The plugin I am creating will use `pre-` and `post-` as the prefix. I use this package and wanted to keep using it without patching it per project to make use of it.

From yarn docs.
`
In particular, we intentionally don't support arbitrary pre and post hooks for user-defined scripts (such as prestart). This behavior, inherited from npm, caused scripts to be implicit rather than explicit, obfuscating the execution flow. It also led to surprising executions with yarn serve also running yarn preserve.
`