### PR TITLE
fix: typescript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,26 +1,38 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-/**
-   Sort packageJson.
+declare namespace sortPackageJsonExports {
+  interface SortPackageJsonFn {
+    /**
+      * Sort packageJson object.
+      *
+      * @param packageJson - A packageJson
+      * @param options
+      * @returns Sorted packageJson object
+      */
+    <T extends Record<any, any>>(packageJson: T, options?: Options): T,
 
-   @param packageJson - A packageJson object or string.
-   @param options
-   @returns Sorted packageJson object or string.
- */
-declare function sortPackageJsonCore<T extends Record<any, any>>(packageJson: T, options?: sortPackageJsonCore.Options): T;
-declare namespace sortPackageJsonCore {
-  var sortPackageJson: <T extends Record<any, any>>(packageJson: T, options?: sortPackageJsonCore.Options) => T;
-  // @ts-ignore
-  var default: <T extends Record<any, any>>(packageJson: T, options?: sortPackageJsonCore.Options) => T;
-}
-declare namespace sortPackageJsonCore {
+    /**
+      * Sort packageJson string.
+      *
+      * @param packageJson - A packageJson string.
+      * @param options
+      * @returns Sorted packageJson string.
+      */
+    (packageJson: string, options?: Options): string,
+  }
+
   type ComparatorFunction = (left: string, right: string) => number;
+
   interface Options {
     readonly sortOrder?: readonly string[] | ComparatorFunction;
   }
-  /**
-   Default sort order.
-   */
-  const sortOrder: readonly string[];
 }
-export = sortPackageJsonCore;
+
+interface sortPackageJsonExports extends sortPackageJsonExports.SortPackageJsonFn {
+  readonly default: sortPackageJsonExports.SortPackageJsonFn;
+  readonly sortPackageJson: sortPackageJsonExports.SortPackageJsonFn;
+}
+
+declare const sortPackageJsonExports: sortPackageJsonExports;
+
+export = sortPackageJsonExports;


### PR DESCRIPTION
- add override for string version of function
- fix default export error in Typescript 3.9

With the changes, Typescirpt doesn't complain given this source:
```ts
import * as sortPackageJson from "sort-package-json";
import sortPackageJsonDefault from "sort-package-json";
import {
  sortPackageJson as sortPackageJsonNamed,
  ComparatorFunction,
  Options,
  SortPackageJsonFn
} from "sort-package-json";

const obj01: object = sortPackageJson({});
const obj02: object = sortPackageJson({}, {});
const obj03: object = sortPackageJson.default({});
const obj04: object = sortPackageJson.default({}, {});
const obj05: object = sortPackageJson.sortPackageJson({});
const obj06: object = sortPackageJson.sortPackageJson({}, {});
const obj07: object = sortPackageJsonDefault({});
const obj08: object = sortPackageJsonDefault({}, {});
const obj09: object = sortPackageJsonNamed({});
const obj10: object = sortPackageJsonNamed({}, {});

const str01: string = sortPackageJson("{}");
const str02: string = sortPackageJson("{}", {});
const str03: string = sortPackageJson.default("{}");
const str04: string = sortPackageJson.default("{}", {});
const str05: string = sortPackageJson.sortPackageJson("{}");
const str06: string = sortPackageJson.sortPackageJson("{}", {});
const str07: string = sortPackageJsonDefault("{}");
const str08: string = sortPackageJsonDefault("{}", {});
const str09: string = sortPackageJsonNamed("{}");
const str10: string = sortPackageJsonNamed("{}", {});
```