### PR TITLE
Update lint-staged instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,7 @@ The package.json file can be sorted automatically before committing, install `hu
     }
   },
   "lint-staged": {
-    "package.json": [
-      "sort-package-json",
-      "git add"
-    ]
+    "package.json": "sort-package-json"
   }
 }
 ```


### PR DESCRIPTION
lint-staged no longer wants git-add add ran on it's behalf

https://github.com/okonet/lint-staged#v10
> From v10.0.0 onwards any new modifications to originally staged files will be automatically added to the commit. If your task previously contained a git add step, please remove this. The automatic behaviour ensures there are less race-conditions, since trying to run multiple git operations at the same time usually results in an error.