### PR TITLE
fix: stop sorting scripts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,6 @@ declare namespace sortPackageJson {
 
   interface Options {
     readonly sortOrder?: readonly string[] | ComparatorFunction
-    readonly fields?: Field[]
   }
 }
 
@@ -43,7 +42,6 @@ interface sortPackageJsonExports extends sortPackageJson.SortPackageJsonFn {
   readonly default: sortPackageJson.SortPackageJsonFn
   readonly sortPackageJson: sortPackageJson.SortPackageJsonFn
   readonly sortOrder: string[]
-  readonly sortObjectBy: typeof sortPackageJson.sortObjectBy
 }
 
 declare const sortPackageJsonExports: sortPackageJsonExports

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,36 +3,49 @@
 declare namespace sortPackageJsonExports {
   interface SortPackageJsonFn {
     /**
-      * Sort packageJson object.
-      *
-      * @param packageJson - A packageJson
-      * @param options
-      * @returns Sorted packageJson object
-      */
-    <T extends Record<any, any>>(packageJson: T, options?: Options): T,
+     * Sort packageJson object.
+     *
+     * @param packageJson - A packageJson
+     * @param options
+     * @returns Sorted packageJson object
+     */
+    <T extends Record<any, any>>(packageJson: T, options?: Options): T
 
     /**
-      * Sort packageJson string.
-      *
-      * @param packageJson - A packageJson string.
-      * @param options
-      * @returns Sorted packageJson string.
-      */
-    (packageJson: string, options?: Options): string,
+     * Sort packageJson string.
+     *
+     * @param packageJson - A packageJson string.
+     * @param options
+     * @returns Sorted packageJson string.
+     */
+    (packageJson: string, options?: Options): string
   }
 
-  type ComparatorFunction = (left: string, right: string) => number;
+  type ComparatorFunction = (left: string, right: string) => number
+  function sortObjectBy<T extends Record<any, any>>(
+    comparator: string[],
+    deep: boolean,
+  ): (x: T) => T
+
+  interface Field {
+    readonly key: string
+    readonly over: sortObjectBy
+  }
 
   interface Options {
-    readonly sortOrder?: readonly string[] | ComparatorFunction;
+    readonly sortOrder?: readonly string[] | ComparatorFunction
+    readonly fields?: Field[]
   }
 }
 
-interface sortPackageJsonExports extends sortPackageJsonExports.SortPackageJsonFn {
-  readonly default: sortPackageJsonExports.SortPackageJsonFn;
-  readonly sortPackageJson: sortPackageJsonExports.SortPackageJsonFn;
+interface sortPackageJsonExports
+  extends sortPackageJsonExports.SortPackageJsonFn {
+  readonly default: sortPackageJsonExports.SortPackageJsonFn
+  readonly sortPackageJson: sortPackageJsonExports.SortPackageJsonFn
+  readonly sortOrder: string[]
+  readonly sortObjectBy: sortPackageJsonExports.sortObjectBy
 }
 
-declare const sortPackageJsonExports: sortPackageJsonExports;
+declare const sortPackageJsonExports: sortPackageJsonExports
 
-export = sortPackageJsonExports;
+export = sortPackageJsonExports

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-declare namespace sortPackageJsonExports {
+declare namespace sortPackageJson {
   interface SortPackageJsonFn {
     /**
      * Sort packageJson object.
      *
      * @param packageJson - A packageJson
-     * @param options
+     * @param options - An options object
      * @returns Sorted packageJson object
      */
     <T extends Record<any, any>>(packageJson: T, options?: Options): T
@@ -15,21 +15,22 @@ declare namespace sortPackageJsonExports {
      * Sort packageJson string.
      *
      * @param packageJson - A packageJson string.
-     * @param options
+     * @param options - An options object
      * @returns Sorted packageJson string.
      */
     (packageJson: string, options?: Options): string
   }
 
   type ComparatorFunction = (left: string, right: string) => number
+
   function sortObjectBy<T extends Record<any, any>>(
-    comparator: string[],
-    deep: boolean,
+    comparator?: string[],
+    deep?: boolean,
   ): (x: T) => T
 
   interface Field {
     readonly key: string
-    readonly over: sortObjectBy
+    over?<T extends Record<any, any>>(x: T): T
   }
 
   interface Options {
@@ -38,12 +39,11 @@ declare namespace sortPackageJsonExports {
   }
 }
 
-interface sortPackageJsonExports
-  extends sortPackageJsonExports.SortPackageJsonFn {
-  readonly default: sortPackageJsonExports.SortPackageJsonFn
-  readonly sortPackageJson: sortPackageJsonExports.SortPackageJsonFn
+interface sortPackageJsonExports extends sortPackageJson.SortPackageJsonFn {
+  readonly default: sortPackageJson.SortPackageJsonFn
+  readonly sortPackageJson: sortPackageJson.SortPackageJsonFn
   readonly sortOrder: string[]
-  readonly sortObjectBy: sortPackageJsonExports.sortObjectBy
+  readonly sortObjectBy: typeof sortPackageJson.sortObjectBy
 }
 
 declare const sortPackageJsonExports: sortPackageJsonExports

--- a/index.js
+++ b/index.js
@@ -134,10 +134,22 @@ const defaultNpmScripts = new Set([
 const sortScripts = (scripts, parent) => {
   if (!isPlainObject(scripts)) return scripts
 
+  // npm-run-all provides commands that are sensitive to script-ordering.
+  // If we detect its usage, do not re-order scripts.
   if (hasOwnProperty(parent, 'devDependencies')) {
     if (Object.keys(parent.devDependencies).includes('npm-run-all')) {
       return scripts
     }
+  }
+
+  // These are the commands that npm-run-all provides that are sensitive to script-ordering
+  // Explicitly check for them in case npm-run-all is installed globally
+  if (Object.values(scripts).some((script) => script.includes('npm-run-all'))) {
+    return scripts
+  }
+
+  if (Object.values(scripts).some((script) => script.includes('run-s'))) {
+    return scripts
   }
 
   const names = Object.keys(scripts)

--- a/index.js
+++ b/index.js
@@ -280,14 +280,15 @@ const fields = [
 ]
 
 const defaultSortOrder = fields.map(({ key }) => key)
-const overFields = pipe(
-  fields.reduce((fns, { key, over }) => {
-    if (over) {
-      fns.push(overProperty(key, over))
-    }
-    return fns
-  }, []),
-)
+const overFields = (fields) =>
+  pipe(
+    fields.reduce((fns, { key, over }) => {
+      if (over) {
+        fns.push(overProperty(key, over))
+      }
+      return fns
+    }, []),
+  )
 
 function editStringJSON(json, over) {
   if (typeof json === 'string') {
@@ -332,7 +333,16 @@ function sortPackageJson(jsonIsh, options = {}) {
         ]
       }
 
-      return overFields(sortObjectKeys(json, sortOrder))
+      if (options.fields) {
+        for (const field of options.fields) {
+          const idx = fields.findIndex((f) => f.key === field.key)
+
+          if (idx > -1) fields[idx] = field
+          if (idx === -1) fields.push(field)
+        }
+      }
+
+      return overFields(fields)(sortObjectKeys(json, sortOrder))
     }),
   )
 }
@@ -340,4 +350,5 @@ function sortPackageJson(jsonIsh, options = {}) {
 module.exports = sortPackageJson
 module.exports.sortPackageJson = sortPackageJson
 module.exports.sortOrder = defaultSortOrder
+module.exports.sortObjectBy = sortObjectBy
 module.exports.default = sortPackageJson

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,6 +483,79 @@
         "arrify": "^1.0.1"
       }
     },
+    "@definitelytyped/header-parser": {
+      "version": "0.0.60",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@definitelytyped/header-parser/-/header-parser-0.0.60.tgz",
+      "integrity": "sha512-fdfR9DthV9WwUCeLsEIhAJxBjRccX0VnRJIDr9JWbqN3TloKEv/376Lq4/q2zJRUsbJTiKwDxhg6RFwqN34uuA==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/typescript-versions": "^0.0.60",
+        "@types/parsimmon": "^1.10.1",
+        "parsimmon": "^1.13.0"
+      }
+    },
+    "@definitelytyped/typescript-versions": {
+      "version": "0.0.60",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@definitelytyped/typescript-versions/-/typescript-versions-0.0.60.tgz",
+      "integrity": "sha512-zu5qXL3lyhBnoi2pxT8MrG2MfNyY+NRII3JjwF8bedAsisNiGwXz5UN01NREhwAf010zfT3XEWORhTBsIzOXkQ==",
+      "dev": true
+    },
+    "@definitelytyped/utils": {
+      "version": "0.0.60",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@definitelytyped/utils/-/utils-0.0.60.tgz",
+      "integrity": "sha512-USQJzzb3PIJbc/CObC6vEIn2Oum8DaOoXP+qhHoeBEyAwY1YQ6tbX+fBc6k8DHuMY9obdpx/7OUnGE0c8EohHw==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/typescript-versions": "^0.0.60",
+        "@types/node": "^12.12.29",
+        "charm": "^1.0.2",
+        "fs-extra": "^8.1.0",
+        "fstream": "^1.0.12",
+        "npm-registry-client": "^8.6.0",
+        "tar": "^2.2.2",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.19.4",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@types/node/-/node-12.19.4.tgz",
+          "integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -1130,6 +1203,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/parsimmon": {
+      "version": "1.10.4",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@types/parsimmon/-/parsimmon-1.10.4.tgz",
+      "integrity": "sha512-M56NfQHfaWuaj6daSgCVs7jh8fXLI3LmxjRoQxmOvYesgIkI+9HPsDLO0vd7wX7cwA0D0ZWFEJdp0VPwLdS+bQ==",
+      "dev": true
+    },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -1301,11 +1380,29 @@
         "default-require-extensions": "^3.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true,
+      "optional": true
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -1372,10 +1469,31 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "at-least-node": {
@@ -1570,6 +1688,77 @@
         }
       }
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -1612,6 +1801,21 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "before-after-hook": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
@@ -1623,6 +1827,45 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
+    },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
     },
     "blueimp-md5": {
       "version": "2.12.0",
@@ -1727,6 +1970,16 @@
         "fill-range": "^7.0.1"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1737,6 +1990,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "cacheable-request": {
@@ -1842,6 +2101,12 @@
         "redeyed": "~2.1.0"
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -1858,6 +2123,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "charm": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1"
+      }
     },
     "chokidar": {
       "version": "3.3.1",
@@ -2013,6 +2287,21 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true
+    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2063,6 +2352,18 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "concordance": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
@@ -2106,6 +2407,13 @@
         "write-file-atomic": "^3.0.0",
         "xdg-basedir": "^4.0.0"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true,
+      "optional": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2280,6 +2588,15 @@
       "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "date-fns": {
@@ -2471,6 +2788,19 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true,
+      "optional": true
+    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -2486,6 +2816,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -2528,6 +2864,145 @@
         }
       }
     },
+    "dts-critic": {
+      "version": "3.3.3",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/dts-critic/-/dts-critic-3.3.3.tgz",
+      "integrity": "sha512-Pd27sNICo8mUqZ7XBdefy/+eWG8uG02GaYgOv5DBpxiF+8hduojztVm4935dqocyDv/STdF1uh6a8WnAhBK7tQ==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/header-parser": "^0.0.60",
+        "command-exists": "^1.2.8",
+        "rimraf": "^3.0.2",
+        "semver": "^6.2.0",
+        "tmp": "^0.2.1",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "dtslint": {
+      "version": "4.0.5",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/dtslint/-/dtslint-4.0.5.tgz",
+      "integrity": "sha512-gEf7tEQgdMQh38h29B2aVyJBGMb8l/5koVArmc4t3XyeCe0rbElpB0HjOZ6SgUOzvsI05hTOenY66aM9ji3afA==",
+      "dev": true,
+      "requires": {
+        "@definitelytyped/header-parser": "^0.0.60",
+        "@definitelytyped/typescript-versions": "^0.0.60",
+        "@definitelytyped/utils": "^0.0.60",
+        "dts-critic": "^3.3.3",
+        "fs-extra": "^6.0.1",
+        "json-stable-stringify": "^1.0.1",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "5.14.0",
+        "yargs": "^15.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "6.0.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/fs-extra/-/fs-extra-6.0.1.tgz",
+          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -2542,6 +3017,16 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3138,6 +3623,12 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -3148,6 +3639,12 @@
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -3373,6 +3870,23 @@
         }
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -3387,6 +3901,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
       "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-extra": {
@@ -3421,6 +3941,18 @@
       "dev": true,
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3432,6 +3964,64 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3458,6 +4048,15 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "git-hooks-list": {
@@ -3623,6 +4222,36 @@
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3660,6 +4289,13 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true,
+      "optional": true
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -3718,6 +4354,17 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -3814,6 +4461,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.1.4",
@@ -4209,6 +4862,12 @@
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "issue-parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
@@ -4424,6 +5083,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4442,11 +5107,26 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4479,11 +5159,29 @@
         "universalify": "^1.0.0"
       }
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "keyv": {
       "version": "3.1.0",
@@ -5263,6 +5961,21 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
       "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -8956,6 +9669,54 @@
         }
       }
     },
+    "npm-package-arg": {
+      "version": "6.1.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+      "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.7.1",
+        "osenv": "^0.1.5",
+        "semver": "^5.6.0",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "npm-registry-client": {
+      "version": "8.6.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/npm-registry-client/-/npm-registry-client-8.6.0.tgz",
+      "integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.2",
+        "graceful-fs": "^4.1.6",
+        "normalize-package-data": "~1.0.1 || ^2.0.0",
+        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+        "once": "^1.3.3",
+        "request": "^2.74.0",
+        "retry": "^0.10.0",
+        "safe-buffer": "^5.1.1",
+        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+        "slide": "^1.1.3",
+        "ssri": "^5.2.4"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.10.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+          "dev": true
+        }
+      }
+    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -8971,6 +9732,19 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         }
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -9083,6 +9857,12 @@
           }
         }
       }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -9231,6 +10011,12 @@
         }
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -9246,6 +10032,16 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -9419,6 +10215,12 @@
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
       "dev": true
     },
+    "parsimmon": {
+      "version": "1.16.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/parsimmon/-/parsimmon-1.16.0.tgz",
+      "integrity": "sha512-tekGDz2Lny27SQ/5DzJdIK0lqsWwZ667SCLFIDCxaZM7VNgQjyKLbaL7FYPKpbjdxNAXFV/mSxkq5D2fnkW4pA==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9450,6 +10252,12 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.1",
@@ -9659,6 +10467,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -9688,6 +10502,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "quick-lru": {
@@ -9858,6 +10678,34 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -10344,6 +11192,12 @@
         }
       }
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
     "sort-object-keys": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
@@ -10472,6 +11326,32 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "5.3.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ssri/-/ssri-5.3.0.tgz",
+      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "stack-utils": {
       "version": "2.0.1",
@@ -10745,6 +11625,43 @@
         }
       }
     },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.4",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -10849,6 +11766,16 @@
         "is-number": "^7.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -10873,6 +11800,59 @@
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
+    "tslint": {
+      "version": "5.14.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tslint/-/tslint-5.14.0.tgz",
+      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -10888,6 +11868,12 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -10896,6 +11882,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.0.5",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.9.1",
@@ -11065,6 +12057,26 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "^1.0.3"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -11100,6 +12112,53 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "widest-line": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint .",
     "semantic-release": "semantic-release",
     "sort-package-json": "node cli.js package.json --check",
-    "test": "ava",
+    "test": "ava && dtslint --localTs node_modules/typescript/lib ",
     "test-coverage": "nyc ava",
     "update-snapshot": "ava -u && node cli.js package.json"
   },
@@ -84,6 +84,7 @@
     "ava": "3.5.1",
     "del": "5.1.0",
     "dot-prop": "^5.2.0",
+    "dtslint": "^4.0.5",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-config-standard": "^14.1.0",
@@ -98,6 +99,7 @@
     "nyc": "^15.0.0",
     "prettier": "^2.0.4",
     "semantic-release": "17.0.5",
-    "tempy": "0.4.0"
+    "tempy": "0.4.0",
+    "typescript": "^4.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint .",
     "semantic-release": "semantic-release",
     "sort-package-json": "node cli.js package.json --check",
-    "test": "ava && dtslint --localTs node_modules/typescript/lib ",
+    "test": "ava && dtslint --localTs node_modules/typescript/lib",
     "test-coverage": "nyc ava",
     "update-snapshot": "ava -u && node cli.js package.json"
   },

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,6 +1,5 @@
 const test = require('ava')
 const { keysToObject, macro } = require('./_helpers')
-const sortPackageJson = require('..')
 
 test('options.sortOrder', macro.sortObject, {
   options: {
@@ -48,24 +47,4 @@ test('options.sortOrder with private key', macro.sortObject, {
   value: keysToObject(['z', '_a', 'name', '_z', 'a']),
   expect: keysToObject(['_z', 'name', 'a', 'z', '_a']),
   message: 'options.sortOrder should work with private keys`',
-})
-
-test('options.fields with existing key', macro.sortObject, {
-  options: {
-    fields: [{ key: 'scripts' }],
-  },
-  value: `{"scripts":{"z":"","a":""}}`,
-  expect: `{"scripts":{"z":"","a":""}}`,
-  message:
-    'options.fields should work with keys that are already present in the fields list`',
-})
-
-test('options.fields with new key', macro.sortObject, {
-  options: {
-    fields: [{ key: 'new-key', over: sortPackageJson.sortObjectBy() }],
-  },
-  value: `{"new-key":{"z":"","a":""}}`,
-  expect: `{"new-key":{"a":"","z":""}}`,
-  message:
-    'options.fields should work with keys that are not already present in the fields list`',
 })

--- a/tests/options.js
+++ b/tests/options.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 const { keysToObject, macro } = require('./_helpers')
+const sortPackageJson = require('..')
 
 test('options.sortOrder', macro.sortObject, {
   options: {
@@ -47,4 +48,24 @@ test('options.sortOrder with private key', macro.sortObject, {
   value: keysToObject(['z', '_a', 'name', '_z', 'a']),
   expect: keysToObject(['_z', 'name', 'a', 'z', '_a']),
   message: 'options.sortOrder should work with private keys`',
+})
+
+test('options.fields with existing key', macro.sortObject, {
+  options: {
+    fields: [{ key: 'scripts' }],
+  },
+  value: `{"scripts":{"z":"","a":""}}`,
+  expect: `{"scripts":{"z":"","a":""}}`,
+  message:
+    'options.fields should work with keys that are already present in the fields list`',
+})
+
+test('options.fields with new key', macro.sortObject, {
+  options: {
+    fields: [{ key: 'new-key', over: sortPackageJson.sortObjectBy() }],
+  },
+  value: `{"new-key":{"z":"","a":""}}`,
+  expect: `{"new-key":{"a":"","z":""}}`,
+  message:
+    'options.fields should work with keys that are not already present in the fields list`',
 })

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+const sortPackageJson = require('..')
 const { macro } = require('./_helpers')
 
 const fixture = {
@@ -38,5 +39,19 @@ for (const field of ['scripts', 'betterScripts']) {
     path: field,
     value: fixture,
     expect: expect,
+  })
+
+  test(`${field} with npm-run-all`, (t) => {
+    const packageJson = {
+      [field]: fixture,
+      devDependencies: {
+        'npm-run-all': '*',
+      },
+    }
+
+    t.is(
+      sortPackageJson(JSON.stringify(packageJson)),
+      JSON.stringify(packageJson),
+    )
   })
 }

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -7,6 +7,7 @@ const fixture = {
   watch: 'watch things',
   prewatch: 'echo "about to watch"',
   postinstall: 'echo "Installed"',
+  preinstall: 'echo "Installing"',
   start: 'node server.js',
   posttest: 'abc',
   pretest: 'xyz',
@@ -17,10 +18,27 @@ const fixture = {
   'pre-fetch-info': 'foo',
 }
 
+const expect = {
+  pretest: 'xyz',
+  test: 'node test.js',
+  posttest: 'abc',
+  multiply: '2 * 3',
+  prewatch: 'echo "about to watch"',
+  watch: 'watch things',
+  preinstall: 'echo "Installing"',
+  postinstall: 'echo "Installed"',
+  start: 'node server.js',
+  preprettier: 'echo "not pretty"',
+  prettier: 'prettier -l "**/*.js"',
+  postprettier: 'echo "so pretty"',
+  prepare: 'npm run build',
+  'pre-fetch-info': 'foo',
+}
+
 for (const field of ['scripts', 'betterScripts']) {
   test(field, macro.sortObject, {
     path: field,
     value: fixture,
-    expect: fixture,
+    expect,
   })
 }

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -41,12 +41,44 @@ for (const field of ['scripts', 'betterScripts']) {
     expect: expect,
   })
 
-  test(`${field} with npm-run-all`, (t) => {
+  test(`${field} with npm-run-all devDependency`, (t) => {
     const packageJson = {
       [field]: fixture,
       devDependencies: {
         'npm-run-all': '*',
       },
+    }
+
+    t.is(
+      sortPackageJson(JSON.stringify(packageJson)),
+      JSON.stringify(packageJson),
+    )
+  })
+
+  test(`${field} with npm-run-all usage`, (t) => {
+    const newFixture = {
+      ...fixture,
+      test: 'npm-run-all foo:*',
+    }
+
+    const packageJson = {
+      [field]: newFixture,
+    }
+
+    t.is(
+      sortPackageJson(JSON.stringify(packageJson)),
+      JSON.stringify(packageJson),
+    )
+  })
+
+  test(`${field} with run-s usage`, (t) => {
+    const newFixture = {
+      ...fixture,
+      test: 'run-s foo:*',
+    }
+
+    const packageJson = {
+      [field]: newFixture,
     }
 
     t.is(

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -1,5 +1,4 @@
 const test = require('ava')
-const sortPackageJson = require('..')
 const { macro } = require('./_helpers')
 
 const fixture = {
@@ -18,72 +17,10 @@ const fixture = {
   'pre-fetch-info': 'foo',
 }
 
-const expect = {
-  postinstall: 'echo "Installed"',
-  multiply: '2 * 3',
-  'pre-fetch-info': 'foo',
-  prepare: 'npm run build',
-  preprettier: 'echo "not pretty"',
-  prettier: 'prettier -l "**/*.js"',
-  postprettier: 'echo "so pretty"',
-  start: 'node server.js',
-  pretest: 'xyz',
-  test: 'node test.js',
-  posttest: 'abc',
-  prewatch: 'echo "about to watch"',
-  watch: 'watch things',
-}
-
 for (const field of ['scripts', 'betterScripts']) {
   test(field, macro.sortObject, {
     path: field,
     value: fixture,
-    expect: expect,
-  })
-
-  test(`${field} with npm-run-all devDependency`, (t) => {
-    const packageJson = {
-      [field]: fixture,
-      devDependencies: {
-        'npm-run-all': '*',
-      },
-    }
-
-    t.is(
-      sortPackageJson(JSON.stringify(packageJson)),
-      JSON.stringify(packageJson),
-    )
-  })
-
-  test(`${field} with npm-run-all usage`, (t) => {
-    const newFixture = {
-      ...fixture,
-      test: 'npm-run-all foo:*',
-    }
-
-    const packageJson = {
-      [field]: newFixture,
-    }
-
-    t.is(
-      sortPackageJson(JSON.stringify(packageJson)),
-      JSON.stringify(packageJson),
-    )
-  })
-
-  test(`${field} with run-s usage`, (t) => {
-    const newFixture = {
-      ...fixture,
-      test: 'run-s foo:*',
-    }
-
-    const packageJson = {
-      [field]: newFixture,
-    }
-
-    t.is(
-      sortPackageJson(JSON.stringify(packageJson)),
-      JSON.stringify(packageJson),
-    )
+    expect: fixture,
   })
 }

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,0 +1,61 @@
+import sortPackageJson, {
+  sortPackageJson as nestedSorter,
+  sortObjectBy,
+} from 'sort-package-json'
+
+// $ExpectType { a: string; }
+nestedSorter({ a: '' })
+
+// $ExpectType { a: string; }
+sortPackageJson({ a: '' })
+
+// $ExpectType string
+sortPackageJson('{}')
+
+// $ExpectError
+sortPackageJson(1)
+
+// $ExpectType string
+sortPackageJson('{}', {
+  sortOrder: ['a', 'b'],
+})
+
+// $ExpectType string
+sortPackageJson('{}', {
+  sortOrder: (a, b) => 2,
+})
+
+// $ExpectError
+sortPackageJson('{}', {
+  sortOrder: (a, b) => 'not a number',
+})
+
+// $ExpectType string
+sortPackageJson('{}', {
+  fields: [{ key: 'a' }],
+})
+
+// $ExpectType string
+sortPackageJson('{}', {
+  fields: [{ key: 'a', over: sortObjectBy() }],
+})
+
+// $ExpectType string
+sortPackageJson('{}', {
+  fields: [{ key: 'a', over: sortObjectBy(['a']) }],
+})
+
+// $ExpectType string
+sortPackageJson('{}', {
+  fields: [{ key: 'a', over: (x) => x }],
+})
+
+// $ExpectError
+sortPackageJson('{}', {
+  fields: [{ key: 'a', over: '' }],
+})
+
+// $ExpectError
+sortPackageJson('{}', {
+  fields: [{ over: (x) => x }],
+})

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,6 +1,5 @@
 import sortPackageJson, {
   sortPackageJson as nestedSorter,
-  sortObjectBy,
 } from 'sort-package-json'
 
 // $ExpectType { a: string; }
@@ -28,34 +27,4 @@ sortPackageJson('{}', {
 // $ExpectError
 sortPackageJson('{}', {
   sortOrder: (a, b) => 'not a number',
-})
-
-// $ExpectType string
-sortPackageJson('{}', {
-  fields: [{ key: 'a' }],
-})
-
-// $ExpectType string
-sortPackageJson('{}', {
-  fields: [{ key: 'a', over: sortObjectBy() }],
-})
-
-// $ExpectType string
-sortPackageJson('{}', {
-  fields: [{ key: 'a', over: sortObjectBy(['a']) }],
-})
-
-// $ExpectType string
-sortPackageJson('{}', {
-  fields: [{ key: 'a', over: (x) => x }],
-})
-
-// $ExpectError
-sortPackageJson('{}', {
-  fields: [{ key: 'a', over: '' }],
-})
-
-// $ExpectError
-sortPackageJson('{}', {
-  fields: [{ over: (x) => x }],
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+
+        // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+        // If the library is global (cannot be imported via `import` or `require`), leave this out.
+        "baseUrl": ".",
+        "paths": { "sort-package-json": ["."] }
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dtslint.json", // Or "dtslint/dt.json" if on DefinitelyTyped
+    "rules": {
+        "semicolon": false
+    }
+}


### PR DESCRIPTION
The fields option will override the values in the builtin fields array,
allowing users to signify that a given key should not be sorted, or sorted
in a particular way.