### PR TITLE
feat: sort all scripts unless `npm-run-all` is a dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const isPlainObject = require('is-plain-obj')
 const hasOwnProperty = (object, property) =>
   Object.prototype.hasOwnProperty.call(object, property)
 const pipe = (fns) => (x, ...args) =>
-  fns.reduce((result, fn) => fn(x, ...args), x)
+  fns.reduce((result, fn) => fn(result, ...args), x)
 const onArray = (fn) => (x) => (Array.isArray(x) ? fn(x) : x)
 const onStringArray = (fn) => (x) =>
   Array.isArray(x) && x.every((item) => typeof item === 'string') ? fn(x) : x

--- a/index.js
+++ b/index.js
@@ -14,8 +14,7 @@ const onStringArray = (fn) => (x) =>
 const uniq = onStringArray((xs) => xs.filter((x, i) => i === xs.indexOf(x)))
 const sortArray = onStringArray((array) => [...array].sort())
 const uniqAndSortArray = pipe([uniq, sortArray])
-const onObject = (fn) => (x, ...args) =>
-  isPlainObject(x) ? fn(x, ...args) : x
+const onObject = (fn) => (x, ...args) => isPlainObject(x) ? fn(x, ...args) : x
 const sortObjectBy = (comparator, deep) => {
   const over = onObject((object) => {
     object = sortObjectKeys(object, comparator)
@@ -40,9 +39,9 @@ const sortDirectories = sortObjectBy([
   'example',
   'test',
 ])
-const overProperty = (property, over) => (object, packageJson) =>
+const overProperty = (property, over) => (object, ...args) =>
   hasOwnProperty(object, property)
-    ? Object.assign(object, { [property]: over(object[property], packageJson) })
+    ? Object.assign(object, { [property]: over(object[property], ...args) })
     : object
 const sortGitHooks = sortObjectBy(gitHooks)
 

--- a/index.js
+++ b/index.js
@@ -6,16 +6,16 @@ const isPlainObject = require('is-plain-obj')
 
 const hasOwnProperty = (object, property) =>
   Object.prototype.hasOwnProperty.call(object, property)
-const pipe = (fns) => (x, packageJson) =>
-  fns.reduce((result, fn) => fn(result, packageJson), x)
+const pipe = (fns) => (x, ...args) =>
+  fns.reduce((result, fn) => fn(x, ...args), x)
 const onArray = (fn) => (x) => (Array.isArray(x) ? fn(x) : x)
 const onStringArray = (fn) => (x) =>
   Array.isArray(x) && x.every((item) => typeof item === 'string') ? fn(x) : x
 const uniq = onStringArray((xs) => xs.filter((x, i) => i === xs.indexOf(x)))
 const sortArray = onStringArray((array) => [...array].sort())
 const uniqAndSortArray = pipe([uniq, sortArray])
-const onObject = (fn) => (x, packageJson) =>
-  isPlainObject(x) ? fn(x, packageJson) : x
+const onObject = (fn) => (x, ...args) =>
+  isPlainObject(x) ? fn(x, ...args) : x
 const sortObjectBy = (comparator, deep) => {
   const over = onObject((object) => {
     object = sortObjectKeys(object, comparator)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const onStringArray = (fn) => (x) =>
 const uniq = onStringArray((xs) => xs.filter((x, i) => i === xs.indexOf(x)))
 const sortArray = onStringArray((array) => [...array].sort())
 const uniqAndSortArray = pipe([uniq, sortArray])
-const onObject = (fn) => (x, ...args) => isPlainObject(x) ? fn(x, ...args) : x
+const onObject = (fn) => (x, ...args) => (isPlainObject(x) ? fn(x, ...args) : x)
 const sortObjectBy = (comparator, deep) => {
   const over = onObject((object) => {
     object = sortObjectKeys(object, comparator)

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -18,7 +18,24 @@ const fixture = {
   'pre-fetch-info': 'foo',
 }
 
-const expect = {
+const expectAllSorted = {
+  preinstall: 'echo "Installing"',
+  postinstall: 'echo "Installed"',
+  multiply: '2 * 3',
+  'pre-fetch-info': 'foo',
+  prepare: 'npm run build',
+  preprettier: 'echo "not pretty"',
+  prettier: 'prettier -l "**/*.js"',
+  postprettier: 'echo "so pretty"',
+  start: 'node server.js',
+  pretest: 'xyz',
+  test: 'node test.js',
+  posttest: 'abc',
+  prewatch: 'echo "about to watch"',
+  watch: 'watch things',
+}
+
+const expectPreAndPostSorted = {
   pretest: 'xyz',
   test: 'node test.js',
   posttest: 'abc',
@@ -36,9 +53,18 @@ const expect = {
 }
 
 for (const field of ['scripts', 'betterScripts']) {
-  test(field, macro.sortObject, {
-    path: field,
-    value: fixture,
-    expect,
+  test(`${field} when npm-run-all is not a dev dependency`, macro.sortObject, {
+    value: { [field]: fixture },
+    expect: { [field]: expectAllSorted },
+  })
+  test(`${field} when npm-run-all is a dev dependency`, macro.sortObject, {
+    value: {
+      [field]: fixture,
+      devDependencies: { 'npm-run-all': '^1.0.0' },
+    },
+    expect: {
+      [field]: expectPreAndPostSorted,
+      devDependencies: { 'npm-run-all': '^1.0.0' },
+    },
   })
 }


### PR DESCRIPTION
This restores the default behaviour of sorting scripts alphabetically followed by pre & post _unless_ `npm-run-all` is a development dependency in the `package.json` being sorted.

Closes #220 