### PR TITLE
feat: allow script sort for run-p

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,6 +139,29 @@ const hasDevDependency = (dependency, packageJson) => {
   )
 }
 
+const runSValues = [new RegExp('run-s')]
+
+const hasRunS = (packageJson) => {
+  if (hasDevDependency('npm-run-all', packageJson)) {
+    const scripts = packageJson.scripts
+    const betterScripts = packageJson.betterScripts
+
+    if (scripts) {
+      return Object.values(scripts).some((script) =>
+        runSValues.some((runSValue) => runSValue.test(script)),
+      )
+    }
+
+    if (betterScripts) {
+      return Object.values(betterScripts).some((script) =>
+        runSValues.some((runSValue) => runSValue.test(script)),
+      )
+    }
+  }
+
+  return false
+}
+
 const sortScripts = onObject((scripts, packageJson) => {
   const names = Object.keys(scripts)
   const prefixable = new Set()
@@ -152,7 +175,7 @@ const sortScripts = onObject((scripts, packageJson) => {
     return name
   })
 
-  if (!hasDevDependency('npm-run-all', packageJson)) {
+  if (!hasRunS(packageJson)) {
     keys.sort()
   }
 
@@ -163,8 +186,9 @@ const sortScripts = onObject((scripts, packageJson) => {
       ),
     [],
   )
+  const toReturn = sortObjectKeys(scripts, order)
 
-  return sortObjectKeys(scripts, order)
+  return toReturn
 })
 
 // fields marked `vscode` are for `Visual Studio Code extension manifest` only

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -18,6 +18,23 @@ const fixture = {
   'pre-fetch-info': 'foo',
 }
 
+const fixtureWithRunS = {
+  test: 'node test.js',
+  multiply: '2 * 3', // between p(ostinstall) and install
+  watch: 'watch things',
+  prewatch: 'echo "about to watch"',
+  postinstall: 'echo "Installed"',
+  preinstall: 'echo "Installing"',
+  start: 'node server.js',
+  posttest: 'run-s abc def',
+  pretest: 'xyz',
+  postprettier: 'echo "so pretty"',
+  preprettier: 'echo "not pretty"',
+  prettier: 'prettier -l "**/*.js"',
+  prepare: 'npm run build',
+  'pre-fetch-info': 'foo',
+}
+
 const expectAllSorted = {
   preinstall: 'echo "Installing"',
   postinstall: 'echo "Installed"',
@@ -38,7 +55,7 @@ const expectAllSorted = {
 const expectPreAndPostSorted = {
   pretest: 'xyz',
   test: 'node test.js',
-  posttest: 'abc',
+  posttest: 'run-s abc def',
   multiply: '2 * 3',
   prewatch: 'echo "about to watch"',
   watch: 'watch things',
@@ -53,18 +70,39 @@ const expectPreAndPostSorted = {
 }
 
 for (const field of ['scripts', 'betterScripts']) {
-  test(`${field} when npm-run-all is not a dev dependency`, macro.sortObject, {
+  test(`${field} when npm-run-all is NOT a dev dependency`, macro.sortObject, {
     value: { [field]: fixture },
     expect: { [field]: expectAllSorted },
   })
-  test(`${field} when npm-run-all is a dev dependency`, macro.sortObject, {
-    value: {
-      [field]: fixture,
-      devDependencies: { 'npm-run-all': '^1.0.0' },
+
+  for (const type of ['run-s']) {
+    test(
+      `${field} when npm-run-all IS a dev dependency, and IS used in scripts in form of ${type}`,
+      macro.sortObject,
+      {
+        value: {
+          [field]: fixtureWithRunS,
+          devDependencies: { 'npm-run-all': '^1.0.0' },
+        },
+        expect: {
+          [field]: expectPreAndPostSorted,
+          devDependencies: { 'npm-run-all': '^1.0.0' },
+        },
+      },
+    )
+  }
+  test(
+    `${field} when npm-run-all IS a dev dependency, but is NOT used in scripts`,
+    macro.sortObject,
+    {
+      value: {
+        [field]: fixture,
+        devDependencies: { 'npm-run-all': '^1.0.0' },
+      },
+      expect: {
+        [field]: expectAllSorted,
+        devDependencies: { 'npm-run-all': '^1.0.0' },
+      },
     },
-    expect: {
-      [field]: expectPreAndPostSorted,
-      devDependencies: { 'npm-run-all': '^1.0.0' },
-    },
-  })
+  )
 }


### PR DESCRIPTION
### Background

This package does not currently support sorting the `scripts` field of a `package.json` when `npm-run-all` is a devDependency, regardless of how it is actually used in the scripts.

While there is certainly a place for refraining from sorting the scripts when `npm-run-all` is used for running scripts sequentially (e.g. `npm-run-all --serial`), there are use cases where the user may wish for the scripts to be sorted even when `npm-run-all` is a devDepenency (e.g. `npm-run-all -p`). This concern has been raised in previous PRs and issues (see [this PR](https://github.com/keithamus/sort-package-json/pull/206) and [this issue](https://github.com/keithamus/sort-package-json/issues/220)). 

**This PR enables this behavior.**

### Changes

The following uses of `npm-run-all` will continue to NOT sort the `scripts`:
- `npm-run-all`
- `npm-run-all --serial`
- `npm-run-all --sequential`
- `npm-run-all -s`
- `run-s`

While the following uses now WILL sort the `scripts`:
- `npm-run-all --parallel`
- `run-p`
- 

