### PR TITLE
feat: sort regardless of devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,15 @@ It sorts using [`sort-object-keys`](http://github.com/keithamus/sort-object-keys
 
 Cool. Send a PR! It might get denied if it is a specific vendor key of an unpopular project (e.g. `"my-super-unknown-project"`). We sort keys like "browserify" because it is a project with millions of users. If your project has, say, over 100 users, then we'll add it. Sound fair?
 
+### Can I disable sorting X?
+
+There's been discourse over this, especially when considering scripts that contain `npm-run-all`. The argument is that sorting scripts _can_ have a runtime effect. In this case (running scripts in series) there may be some dependencies between scripts that require a specific order. We decided not to do this for the following reasons:
+
+- Enforcing ordering of scripts by alphanumeric sorting is frail and implicit. The dependencies between scripts isn't clear and can breaking for many reasons, sorting being the least of them. These depdendencies should be explicit: rather than `"build": "run-s build:*"` requiring a specific order in package.json, it should be refactored to `"build": "run-s codegen:* && run-s build:*"`, for example.
+- Disabling for `npm-run-all` (and `run-s` but _not_ `run-p`) is the tip of the iceberg. This is likely not the only cli that can take into package.json order; creating exceptions for each one isn't feasible. `sort-package-json` should be expected to sort package.json.
+
+[#206](https://github.com/keithamus/sort-package-json/pull/206), [#220](https://github.com/keithamus/sort-package-json/issues/220), [#240](https://github.com/keithamus/sort-package-json/pull/240), [#242](https://github.com/keithamus/sort-package-json/issues/242), & [#244](https://github.com/keithamus/sort-package-json/issues/244) address the changes that landed us here.
+
 ### Isn't this just like Project X?
 
 Could be. I wanted this one because at the time of writing, nothing is:

--- a/index.js
+++ b/index.js
@@ -139,14 +139,7 @@ const defaultNpmScripts = new Set([
   'version',
 ])
 
-const hasDevDependency = (dependency, packageJson) => {
-  return (
-    'devDependencies' in packageJson &&
-    !!packageJson.devDependencies[dependency]
-  )
-}
-
-const sortScripts = onObject((scripts, packageJson) => {
+const sortScripts = onObject((scripts) => {
   const names = Object.keys(scripts)
   const prefixable = new Set()
 
@@ -159,9 +152,7 @@ const sortScripts = onObject((scripts, packageJson) => {
     return name
   })
 
-  if (!hasDevDependency('npm-run-all', packageJson)) {
-    keys.sort()
-  }
+  keys.sort()
 
   const order = keys.reduce(
     (order, key) =>

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -35,23 +35,6 @@ const expectAllSorted = {
   watch: 'watch things',
 }
 
-const expectPreAndPostSorted = {
-  pretest: 'xyz',
-  test: 'node test.js',
-  posttest: 'abc',
-  multiply: '2 * 3',
-  prewatch: 'echo "about to watch"',
-  watch: 'watch things',
-  preinstall: 'echo "Installing"',
-  postinstall: 'echo "Installed"',
-  start: 'node server.js',
-  preprettier: 'echo "not pretty"',
-  prettier: 'prettier -l "**/*.js"',
-  postprettier: 'echo "so pretty"',
-  prepare: 'npm run build',
-  'pre-fetch-info': 'foo',
-}
-
 for (const field of ['scripts', 'betterScripts']) {
   test(`${field} when npm-run-all is not a dev dependency`, macro.sortObject, {
     value: { [field]: fixture },
@@ -63,7 +46,7 @@ for (const field of ['scripts', 'betterScripts']) {
       devDependencies: { 'npm-run-all': '^1.0.0' },
     },
     expect: {
-      [field]: expectPreAndPostSorted,
+      [field]: expectAllSorted,
       devDependencies: { 'npm-run-all': '^1.0.0' },
     },
   })


### PR DESCRIPTION
This package does not currently support sorting the scripts field of a package.json when `npm-run-all` is a devDependency.

This PR proposes that `sort-package-json` should sort package.json, not create these exceptions, and revert those changes. They are unpredictable and hard to detect even with proper documentation. `npm-run-all` is likely not the only cli that can be concerned with script order and handling more of them isn't feasible. This has been brought up many times (#206, #220, #240, #242) and, since there are ultimately two conflicting schools of thought with no mitigation that allows both to exist, requires `sort-package-json` to pick one way or the other.