### PR TITLE
feat(cli): added --version and --help options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -30,9 +30,13 @@ Strings passed as files are parsed as globs.
 
 if (isVersion) {
   try {
+    const path = await import('node:path')
+
     const cliRealPath = fs.realpathSync(process.argv[1])
-    const cliParentDir = (await import('node:path')).dirname(cliRealPath)
-    const packageJsonBuffer = fs.readFileSync(`${cliParentDir}/package.json`)
+    const cliParentDir = path.dirname(cliRealPath)
+    const packageJsonBuffer = fs.readFileSync(
+      path.join(cliParentDir, 'package.json'),
+    )
     const { version } = JSON.parse(packageJsonBuffer)
 
     console.log(`sort-package-json ${version}`)

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ import sortPackageJson from './index.js'
 const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
 const isHelpFlag = (argument) => argument === '--help' || argument === '-h'
 const isVersionFlag = (argument) =>
-  argument === '--version' || argument === '-V'
+  argument === '--version' || argument === '-v'
 
 const cliArguments = process.argv.slice(2)
 const isCheck = cliArguments.some(isCheckFlag)

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { globbySync } from 'globby'
 import fs from 'node:fs'
+import { fileURLToPath } from 'url'
 import sortPackageJson from './index.js'
 
 const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
@@ -27,11 +28,10 @@ Strings passed as files are parsed as globs.
   )
   process.exit(0)
 }
-
 if (isVersion) {
   try {
     const cliParentDir = new URL('package.json', import.meta.url)
-    const packageJsonBuffer = fs.readFileSync(cliParentDir.pathname)
+    const packageJsonBuffer = fs.readFileSync(fileURLToPath(cliParentDir))
     const { version } = JSON.parse(packageJsonBuffer)
 
     console.log(`sort-package-json ${version}`)

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { globbySync } from 'globby'
 import fs from 'node:fs'
+import path from 'node:path'
 import sortPackageJson from './index.js'
 
 const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
@@ -29,9 +30,17 @@ Strings passed as files are parsed as globs.
 }
 
 if (isVersion) {
-  const packageBuffer = fs.readFileSync('./package.json')
-  const { version } = JSON.parse(packageBuffer)
-  console.log(`sort-package-json ${version}`)
+  try {
+    const cliRealPath = fs.realpathSync(process.argv[1])
+    const cliParentDir = path.dirname(cliRealPath)
+    const packageJsonBuffer = fs.readFileSync(`${cliParentDir}/package.json`)
+    const { version } = JSON.parse(packageJsonBuffer)
+
+    console.log(`sort-package-json ${version}`)
+  } catch {
+    // If anything goes wrong, fall back to 'unknown version'
+    console.log(`sort-package-json unknown version`)
+  }
   process.exit(0)
 }
 

--- a/cli.js
+++ b/cli.js
@@ -28,16 +28,11 @@ Strings passed as files are parsed as globs.
   process.exit(0)
 }
 if (isVersion) {
-  try {
-    const cliParentDir = new URL('package.json', import.meta.url)
-    const packageJsonBuffer = fs.readFileSync(cliParentDir)
-    const { version } = JSON.parse(packageJsonBuffer)
+  const cliParentDir = new URL('package.json', import.meta.url)
+  const packageJsonBuffer = fs.readFileSync(cliParentDir)
+  const { version } = JSON.parse(packageJsonBuffer)
 
-    console.log(`sort-package-json ${version}`)
-  } catch {
-    // If anything goes wrong, fall back to 'unknown version'
-    console.log(`sort-package-json unknown version`)
-  }
+  console.log(`sort-package-json ${version}`)
   process.exit(0)
 }
 

--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,6 @@ Sort npm package.json files. Default: ./package.json
 Strings passed as files are parsed as globs.
 
   -c, --check                check if FILES are sorted
-  -q, --quiet                don't output success messages
   -h, --help                 display this help and exit
   -v, --version              display the version and exit
   `,

--- a/cli.js
+++ b/cli.js
@@ -30,13 +30,8 @@ Strings passed as files are parsed as globs.
 
 if (isVersion) {
   try {
-    const path = await import('node:path')
-
-    const cliRealPath = fs.realpathSync(process.argv[1])
-    const cliParentDir = path.dirname(cliRealPath)
-    const packageJsonBuffer = fs.readFileSync(
-      path.join(cliParentDir, 'package.json'),
-    )
+    const cliParentDir = new URL('package.json', import.meta.url)
+    const packageJsonBuffer = fs.readFileSync(cliParentDir.pathname)
     const { version } = JSON.parse(packageJsonBuffer)
 
     console.log(`sort-package-json ${version}`)

--- a/cli.js
+++ b/cli.js
@@ -22,7 +22,7 @@ Strings passed as files are parsed as globs.
   -c, --check                check if FILES are sorted
   -q, --quiet                don't output success messages
   -h, --help                 display this help and exit
-  -V, --version              display the version and exit
+  -v, --version              display the version and exit
   `,
   )
   process.exit(0)

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { globbySync } from 'globby'
 import fs from 'node:fs'
-import { fileURLToPath } from 'url'
 import sortPackageJson from './index.js'
 
 const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
@@ -31,7 +30,7 @@ Strings passed as files are parsed as globs.
 if (isVersion) {
   try {
     const cliParentDir = new URL('package.json', import.meta.url)
-    const packageJsonBuffer = fs.readFileSync(fileURLToPath(cliParentDir))
+    const packageJsonBuffer = fs.readFileSync(cliParentDir)
     const { version } = JSON.parse(packageJsonBuffer)
 
     console.log(`sort-package-json ${version}`)

--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,39 @@
 #!/usr/bin/env node
-import fs from 'node:fs'
 import { globbySync } from 'globby'
+import fs from 'node:fs'
 import sortPackageJson from './index.js'
 
 const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
+const isHelpFlag = (argument) => argument === '--help' || argument === '-h'
+const isVersionFlag = (argument) =>
+  argument === '--version' || argument === '-V'
 
 const cliArguments = process.argv.slice(2)
 const isCheck = cliArguments.some(isCheckFlag)
+const isHelp = cliArguments.some(isHelpFlag)
+const isVersion = cliArguments.some(isVersionFlag)
+
+if (isHelp) {
+  console.log(
+    `Usage: sort-package-json [OPTION...] [FILE...]
+Sort npm package.json files. Default: ./package.json
+Strings passed as files are parsed as globs.
+
+  -c, --check                check if FILES are sorted
+  -q, --quiet                don't output success messages
+  -h, --help                 display this help and exit
+  -V, --version              display the version and exit
+  `,
+  )
+  process.exit(0)
+}
+
+if (isVersion) {
+  const packageBuffer = fs.readFileSync('./package.json')
+  const { version } = JSON.parse(packageBuffer)
+  console.log(`sort-package-json ${version}`)
+  process.exit(0)
+}
 
 const patterns = cliArguments.filter((argument) => !isCheckFlag(argument))
 

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { globbySync } from 'globby'
 import fs from 'node:fs'
-import path from 'node:path'
 import sortPackageJson from './index.js'
 
 const isCheckFlag = (argument) => argument === '--check' || argument === '-c'
@@ -32,7 +31,7 @@ Strings passed as files are parsed as globs.
 if (isVersion) {
   try {
     const cliRealPath = fs.realpathSync(process.argv[1])
-    const cliParentDir = path.dirname(cliRealPath)
+    const cliParentDir = (await import('node:path')).dirname(cliRealPath)
     const packageJsonBuffer = fs.readFileSync(`${cliParentDir}/package.json`)
     const { version } = JSON.parse(packageJsonBuffer)
 

--- a/cli.js
+++ b/cli.js
@@ -28,8 +28,8 @@ Strings passed as files are parsed as globs.
   process.exit(0)
 }
 if (isVersion) {
-  const cliParentDir = new URL('package.json', import.meta.url)
-  const packageJsonBuffer = fs.readFileSync(cliParentDir)
+  const packageJsonUrl = new URL('package.json', import.meta.url)
+  const packageJsonBuffer = fs.readFileSync(packageJsonUrl)
   const { version } = JSON.parse(packageJsonBuffer)
 
   console.log(`sort-package-json ${version}`)


### PR DESCRIPTION
added --version (-V) and --help (-h) options to the CLI for user interface.

## `--help` output:
```
Usage: sort-package-json [OPTION...] [FILE...]
Sort npm package.json files. Default: ./package.json
Strings passed as files are parsed as globs.

  -c, --check                 check if FILES are sorted
  -q, --quiet                  don't output success messages
  -h, --help                   display this help and exit
  -V, --version              display the version and exit
  
```
This help menu can be easily modified in cli.js. It includes the option from #281, but that could be easily removed if so desired.

## `--version` output:
```
sort-package-json 0.0.0-development
```
Or other such versions. The version is pulled from the project.json file in the cli script's directory.
This is found by reading process.env[1], using fs.realpathSync, to read symlinks when it's installed, and path.dirname to get the parent directory. From there it is simple to read the file and call JSON.parse.