### PR TITLE
fix: modernize type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,49 +1,33 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-declare namespace sortPackageJson {
-  interface SortPackageJsonFn {
-    /**
-     * Sort packageJson object.
-     *
-     * @param packageJson - A packageJson
-     * @param options - An options object
-     * @returns Sorted packageJson object
-     */
-    <T extends Record<any, any>>(packageJson: T, options?: Options): T
+type ComparatorFunction = (left: string, right: string) => number
 
-    /**
-     * Sort packageJson string.
-     *
-     * @param packageJson - A packageJson string.
-     * @param options - An options object
-     * @returns Sorted packageJson string.
-     */
-    (packageJson: string, options?: Options): string
-  }
-
-  type ComparatorFunction = (left: string, right: string) => number
-
-  function sortObjectBy<T extends Record<any, any>>(
-    comparator?: string[],
-    deep?: boolean,
-  ): (x: T) => T
-
-  interface Field {
-    readonly key: string
-    over?<T extends Record<any, any>>(x: T): T
-  }
-
-  interface Options {
-    readonly sortOrder?: readonly string[] | ComparatorFunction
-  }
+interface Options {
+  readonly sortOrder?: readonly string[] | ComparatorFunction
 }
 
-interface sortPackageJsonExports extends sortPackageJson.SortPackageJsonFn {
-  readonly default: sortPackageJson.SortPackageJsonFn
-  readonly sortPackageJson: sortPackageJson.SortPackageJsonFn
-  readonly sortOrder: string[]
+interface SortPackageJson {
+  /**
+   * Sort packageJson object.
+   *
+   * @param packageJson - A packageJson
+   * @param options - An options object
+   * @returns Sorted packageJson object
+   */
+  <T extends Record<any, any>>(packageJson: T, options?: Options): T
+
+  /**
+   * Sort packageJson string.
+   *
+   * @param packageJson - A packageJson string.
+   * @param options - An options object
+   * @returns Sorted packageJson string.
+   */
+  (packageJson: string, options?: Options): string
 }
 
-declare const sortPackageJsonExports: sortPackageJsonExports
+declare const sortPackageJsonDefault: SortPackageJson
+export default sortPackageJsonDefault
 
-export = sortPackageJsonExports
+export const sortPackageJson: SortPackageJson
+export const sortOrder: string[]


### PR DESCRIPTION
I get this error when I check my code that imports `sort-package-json`.

```
node_modules/sort-package-json/index.d.ts:49:1 - error TS1203: Export assignment cannot be used when
targeting ECMAScript modules. Consider using 'export default' or another module format instead.

49 export = sortPackageJsonExports
```

In this pull request, I've replaced the old syntax `export=` by `export default` and `export`. I've also removed `sortObjectBy` and `Field` that weren't being used.