### PR TITLE
feat: Introduce option for sorting deps in the same ordering as npm

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -29,9 +29,9 @@ If file/glob is omitted, './package.json' file will be processed.
   )
 }
 
-function sortPackageJsonFile(file, reporter, isCheck) {
+function sortPackageJsonFile(file, reporter, isCheck, sortUsingNpmV7Ording) {
   const original = fs.readFileSync(file, 'utf8')
-  const sorted = sortPackageJson(original)
+  const sorted = sortPackageJson(original, { sortUsingNpmV7Ording })
   if (sorted === original) {
     return reporter.reportNotChanged(file)
   }
@@ -46,11 +46,11 @@ function sortPackageJsonFile(file, reporter, isCheck) {
 function sortPackageJsonFiles(patterns, options) {
   const files = globbySync(patterns)
   const reporter = new Reporter(files, options)
-  const { isCheck } = options
+  const { isCheck, sortUsingNpmV7Ording } = options
 
   for (const file of files) {
     try {
-      sortPackageJsonFile(file, reporter, isCheck)
+      sortPackageJsonFile(file, reporter, isCheck, sortUsingNpmV7Ording)
     } catch (error) {
       reporter.reportFailed(file, error)
     }
@@ -87,12 +87,15 @@ function run() {
   const patterns = []
   let isCheck = false
   let shouldBeQuiet = false
+  let sortUsingNpmV7Ording = false
 
   for (const argument of cliArguments) {
     if (argument === '--check' || argument === '-c') {
       isCheck = true
     } else if (argument === '--quiet' || argument === '-q') {
       shouldBeQuiet = true
+    } else if (argument === "--npm-sort-ordering") {
+      sortUsingNpmV7Ording = true
     } else {
       patterns.push(argument)
     }
@@ -102,7 +105,7 @@ function run() {
     patterns[0] = 'package.json'
   }
 
-  sortPackageJsonFiles(patterns, { isCheck, shouldBeQuiet })
+  sortPackageJsonFiles(patterns, { isCheck, shouldBeQuiet, sortUsingNpmV7Ording })
 }
 
 run()

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,19 @@ type ComparatorFunction = (left: string, right: string) => number
 
 interface Options {
   readonly sortOrder?: readonly string[] | ComparatorFunction
+
+  /**
+   * When `true`, sort using `localCompare` using the region `"en"`.
+   * When `false`, sort using normal `<`, `===`, and `>` operators.
+   * 
+   * This is useful when using `npm` with version `>=7.0.0` since that is how it sorts:
+   *  - `dependencies`
+   *  - `devDependencies`
+   *  - `peerDependencies`
+   *  - `optionalDependencies`
+   * @default false
+   */
+  readonly sortUsingNpmV7Ording?: boolean;
 }
 
 interface SortPackageJson {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,18 @@ const sortObjectBy = (comparator, deep) => {
 
   return over
 }
+
+let sortUsingNpmV7Ording = false
+
+const nonLocalCompare = (left, right) => left < right ? -1 : left === right ? 0 : 1;
+
+const sortDependenciesObject = sortObjectBy((left, right) => {
+  if (sortUsingNpmV7Ording) {
+    return left.localeCompare(right, "en")
+  }
+
+  return nonLocalCompare(left, right)
+})
 const sortObject = sortObjectBy()
 const sortURLObject = sortObjectBy(['type', 'url'])
 const sortPeopleObject = sortObjectBy(['name', 'email', 'url'])
@@ -279,13 +291,13 @@ const fields = [
   { key: 'c8', over: sortObject },
   { key: 'tap', over: sortObject },
   { key: 'resolutions', over: sortObject },
-  { key: 'dependencies', over: sortObject },
-  { key: 'devDependencies', over: sortObject },
+  { key: 'dependencies', over: sortDependenciesObject },
+  { key: 'devDependencies', over: sortDependenciesObject },
   { key: 'dependenciesMeta', over: sortObjectBy(undefined, true) },
-  { key: 'peerDependencies', over: sortObject },
+  { key: 'peerDependencies', over: sortDependenciesObject },
   // TODO: only sort depth = 2
   { key: 'peerDependenciesMeta', over: sortObjectBy(undefined, true) },
-  { key: 'optionalDependencies', over: sortObject },
+  { key: 'optionalDependencies', over: sortDependenciesObject },
   { key: 'bundledDependencies', over: uniqAndSortArray },
   { key: 'bundleDependencies', over: uniqAndSortArray },
   /* vscode */ { key: 'extensionPack', over: uniqAndSortArray },
@@ -344,6 +356,8 @@ const partition = (array, predicate) =>
     [[], []],
   )
 function sortPackageJson(jsonIsh, options = {}) {
+  sortUsingNpmV7Ording = !!options.sortUsingNpmV7Ording
+
   return editStringJSON(
     jsonIsh,
     onObject((json) => {


### PR DESCRIPTION
- The option is `--npm-sort-ordering`, with the default value of `false`


resolves #234 