### PR TITLE
feat: don’t sort scripts when `npm-run-all2` is installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,10 @@ const sortScripts = onObject((scripts, packageJson) => {
     return name
   })
 
-  if (!hasDevDependency('npm-run-all', packageJson)) {
+  if (
+    !hasDevDependency('npm-run-all', packageJson) &&
+    !hasDevDependency('npm-run-all2', packageJson)
+  ) {
     keys.sort()
   }
 

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -68,3 +68,20 @@ for (const field of ['scripts', 'betterScripts']) {
     },
   })
 }
+
+for (const field of ['scripts', 'betterScripts']) {
+  test(`${field} when npm-run-all2 is not a dev dependency`, macro.sortObject, {
+    value: { [field]: fixture },
+    expect: { [field]: expectAllSorted },
+  })
+  test(`${field} when npm-run-all2 is a dev dependency`, macro.sortObject, {
+    value: {
+      [field]: fixture,
+      devDependencies: { 'npm-run-all2': '^1.0.0' },
+    },
+    expect: {
+      [field]: expectPreAndPostSorted,
+      devDependencies: { 'npm-run-all2': '^1.0.0' },
+    },
+  })
+}


### PR DESCRIPTION
Closes https://github.com/keithamus/sort-package-json/issues/308. Context: https://github.com/keithamus/sort-package-json/pull/232