### PR TITLE
chore: remove `ncp`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "globals": "^16.0.0",
         "husky": "^9.1.7",
         "lint-staged": "^15.4.3",
-        "ncp": "^2.0.0",
         "prettier": "^3.5.2",
         "semantic-release": "^24.2.3",
         "tempy": "^3.1.0",
@@ -7333,15 +7332,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-      "dev": true,
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -18196,12 +18186,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
       "dev": true
     },
     "neo-async": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "globals": "^16.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
-    "ncp": "^2.0.0",
     "prettier": "^3.5.2",
     "semantic-release": "^24.2.3",
     "tempy": "^3.1.0",


### PR DESCRIPTION
This PR removes `ncp` that seems to be unused:

- it was added in #316
- became unused in #346

The `build` script is changing between these two PRs. Looks like that was the only usage of `ncp`. Unless I missed something.