### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
 
       - name: Install dependencies
         run: npm i


### PR DESCRIPTION
#380 didn't trigger release, but the workflow failed  https://github.com/keithamus/sort-package-json/actions/runs/20023942195/job/57416877033#step:5:8

> [semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.6.

Adding `node-version: 'lts/*'` should fix it, since it will install v24.11.1 as I tested.

semantic-release also suggests using `lts/*` https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md#use-nvm