### PR TITLE
ci: drop specified secrets, rely on implicit GH token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,4 @@ jobs:
         run: npm i
 
       - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release --branches=main --debug


### PR DESCRIPTION
This shouldn't be needed due to OIDC, and are causing failures due to push, I believe.