### PR TITLE
fix: handle colon-prefixed script names in sorter

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ function sortScriptNames(keys, prefix = '') {
   for (const key of keys) {
     const rest = prefix ? key.slice(prefix.length + 1) : key
     const idx = rest.indexOf(':')
-    if (idx !== -1) {
+    if (idx > 0) {
       const base = key.slice(0, (prefix ? prefix.length + 1 : 0) + idx)
       if (!groupMap.has(base)) groupMap.set(base, [])
       groupMap.get(base).push(key)

--- a/tests/scripts.js
+++ b/tests/scripts.js
@@ -244,6 +244,34 @@ test('scripts: group base and colon scripts together, do not split with unrelate
   ])
 })
 
+test('scripts: handles names starting with colon and double colons', (t) => {
+  const input = {
+    scripts: {
+      '::delta': 'echo',
+      test: 'echo',
+      ':beta': 'echo',
+      ':alpha:sub': 'echo',
+      ':alpha': 'echo',
+      'test::coverage': 'echo',
+      ':alpha::extra': 'echo',
+      'test:lint': 'echo',
+      'test::smoke': 'echo',
+    },
+  }
+  const sorted = sortPackageJson(input)
+  t.deepEqual(Object.keys(sorted.scripts), [
+    '::delta',
+    ':alpha',
+    ':alpha::extra',
+    ':alpha:sub',
+    ':beta',
+    'test',
+    'test::coverage',
+    'test::smoke',
+    'test:lint',
+  ])
+})
+
 test('scripts: group scripts with multiple colons', (t) => {
   const input = {
     scripts: {


### PR DESCRIPTION
Close #388 