### PR TITLE
chore: exclude git-hooks-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "index.cjs"
   ],
   "scripts": {
-    "build": "esbuild index.js --bundle --platform=node --outfile=index.cjs --external:semver",
+    "build": "esbuild index.js --bundle --platform=node --outfile=index.cjs --external:semver --external:git-hooks-list",
     "fix": "eslint . --fix && prettier . --write && node cli.js \"package.json\"",
     "lint": "eslint . && prettier . \"!**/*.js\" --check && node cli.js \"package.json\" --check",
     "prepare": "husky",


### PR DESCRIPTION
`git-hooks-list` is `require()`-able, so i exclude it from CommonJS bundle. From `22.7kb` to `22.1kb`.
